### PR TITLE
Fix faulty second test run with Consul

### DIFF
--- a/store_test.go
+++ b/store_test.go
@@ -79,7 +79,7 @@ func testWatch(t *testing.T, kv Store) {
 	}()
 
 	// Check for updates
-	timeout := time.After(2 * time.Second)
+	timeout := time.After(4 * time.Second)
 	eventCount := 1
 	for {
 		select {
@@ -298,7 +298,7 @@ func testPutEphemeral(t *testing.T, kv Store) {
 	}
 
 	// Let the session expire
-	time.Sleep(5 * time.Second)
+	time.Sleep(8 * time.Second)
 
 	// Zookeeper: re-create the client
 	if zookeeper {


### PR DESCRIPTION
Adds a little more space for timeouts on watches and key expiration for Consul.

Ultimately for the test to be exhaustive in `PutEphemeral` we need to test `Put` after the failed `Get` and probably add a `teardown` function cleaning up the key space on each store.

Signed-off-by: Alexandre Beslic <abronan@docker.com>