### PR TITLE
Fix conservative TTL multiplier in Consul and unnecessary lock at each Put operation

### DIFF
--- a/script/travis_consul.sh
+++ b/script/travis_consul.sh
@@ -12,7 +12,7 @@ unzip "${CONSUL_VERSION}_linux_amd64.zip"
 
 # make config for minimum ttl
 touch config.json
-echo "{\"session_ttl_min\": \"2s\"}" >> config.json
+echo "{\"session_ttl_min\": \"1s\"}" >> config.json
 
 # check
 ./consul --version

--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -111,19 +111,19 @@ func (s *Consul) refreshSession(pair *api.KVPair) error {
 		if err != nil {
 			return err
 		}
-	}
 
-	lockOpts := &api.LockOptions{
-		Key:     pair.Key,
-		Session: session,
-	}
+		lockOpts := &api.LockOptions{
+			Key:     pair.Key,
+			Session: session,
+		}
 
-	// Lock and ignore if lock is held
-	// It's just a placeholder for the
-	// ephemeral behavior
-	lock, _ := s.client.LockOpts(lockOpts)
-	if lock != nil {
-		lock.Lock(nil)
+		// Lock and ignore if lock is held
+		// It's just a placeholder for the
+		// ephemeral behavior
+		lock, _ := s.client.LockOpts(lockOpts)
+		if lock != nil {
+			lock.Lock(nil)
+		}
 	}
 
 	_, _, err = s.client.Session().Renew(session, nil)

--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -101,8 +101,9 @@ func (s *Consul) refreshSession(pair *api.KVPair) error {
 
 	if session == "" {
 		entry := &api.SessionEntry{
-			Behavior: api.SessionBehaviorDelete,
-			TTL:      s.ephemeralTTL.String(),
+			Behavior:  api.SessionBehaviorDelete,       // Delete the key when the session expires
+			TTL:       ((s.ephemeralTTL) / 2).String(), // Consul multiplies the TTL by 2x
+			LockDelay: 1 * time.Millisecond,            // Virtually disable lock delay
 		}
 
 		// Create the key session

--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -325,18 +325,18 @@ func (s *Consul) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*
 			opts.WaitIndex = meta.LastIndex
 
 			// Return children KV pairs to the channel
-			kv := []*store.KVPair{}
+			kvpairs := []*store.KVPair{}
 			for _, pair := range pairs {
 				if pair.Key == directory {
 					continue
 				}
-				kv = append(kv, &store.KVPair{
+				kvpairs = append(kvpairs, &store.KVPair{
 					Key:       pair.Key,
 					Value:     pair.Value,
 					LastIndex: pair.ModifyIndex,
 				})
 			}
-			watchCh <- kv
+			watchCh <- kvpairs
 		}
 	}()
 

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -292,7 +292,7 @@ func testPutEphemeral(t *testing.T, kv store.Store, otherConn store.Store) {
 	otherConn.Close()
 
 	// Let the session expire
-	time.Sleep(5 * time.Second)
+	time.Sleep(3 * time.Second)
 
 	// Get on firstKey shouldn't work
 	pair, err = kv.Get(firstKey)


### PR DESCRIPTION
From the Consul PR to add TTLs:

> Consul will take the conservative approach of internally multiplying the TTL by 2x

This PR fixes that by dividing the `ttl` by 2 (which brings the ttl behavior on par with `etcd`). There is no check so if the `ttl` provided is `< 20s` the create session will fail if Consul is not properly configured to handle lower `ttl` bounds.

The choices are:
- do the proper check but we'll need an additional parameter to override the default check and accept lower values (for testing as we have a `1s` custom lower bound `ttl` value)
- keep it as it is and assume that people using the lib will provide a reasonable `ttl` according to their setup :grin:/