### PR TITLE
Remove logging in library

### DIFF
--- a/libkv.go
+++ b/libkv.go
@@ -1,7 +1,6 @@
 package libkv
 
 import (
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/consul"
 	"github.com/docker/libkv/store/etcd"
@@ -25,7 +24,6 @@ var (
 // NewStore creates a an instance of store
 func NewStore(backend store.Backend, addrs []string, options *store.Config) (store.Store, error) {
 	if init, exists := initializers[backend]; exists {
-		log.WithFields(log.Fields{"backend": backend}).Debug("Initializing store service")
 		return init(addrs, options)
 	}
 

--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -7,7 +7,6 @@ import (
 	"sync"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libkv/store"
 	api "github.com/hashicorp/consul/api"
 )
@@ -60,7 +59,6 @@ func InitializeConsul(endpoints []string, options *store.Config) (store.Store, e
 	// Creates a new client
 	client, err := api.NewClient(config)
 	if err != nil {
-		log.Errorf("Couldn't initialize consul client..")
 		return nil, err
 	}
 	s.client = client
@@ -312,7 +310,6 @@ func (s *Consul) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*
 			// Get all the childrens
 			pairs, meta, err := kv.List(directory, opts)
 			if err != nil {
-				log.Errorf("consul: %v", err)
 				return
 			}
 

--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
 	"github.com/docker/libkv/store"
 	zk "github.com/samuel/go-zookeeper/zk"
 )
@@ -41,7 +40,6 @@ func InitializeZookeeper(endpoints []string, options *store.Config) (store.Store
 	// Connect to Zookeeper
 	conn, _, err := zk.Connect(endpoints, s.timeout)
 	if err != nil {
-		log.Error(err)
 		return nil, err
 	}
 	s.client = conn


### PR DESCRIPTION
Feel free to close this if you don't agree but I don't like logging in libraries, better to log upstream when using them and have more control over what's logged :)

Signed-off-by: Antonio Murdaca <runcom@linux.com>