### PR TITLE
Support "Atomic Create" in etcd

### DIFF
--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -278,17 +278,31 @@ func (s *Etcd) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*st
 // AtomicPut put a value at "key" if the key has not been
 // modified in the meantime, throws an error if this is the case
 func (s *Etcd) AtomicPut(key string, value []byte, previous *store.KVPair, options *store.WriteOptions) (bool, *store.KVPair, error) {
-	if previous == nil {
-		return false, nil, store.ErrPreviousNotSpecified
-	}
 
 	var meta *etcd.Response
 	var err error
-	if previous.LastIndex != 0 {
+	if previous != nil {
 		meta, err = s.client.CompareAndSwap(store.Normalize(key), string(value), 0, "", previous.LastIndex)
 	} else {
-		// Interpret LastIndex == 0 as atomic create.
+		// Interpret previous == nil as Atomic Create
 		meta, err = s.client.Create(store.Normalize(key), string(value), 0)
+		if etcdError, ok := err.(*etcd.EtcdError); ok {
+
+			// Directory doesn't exist.
+			if etcdError.ErrorCode == 104 {
+				// Remove the last element (the actual key)
+				// and create the full directory path
+				err = s.createDirectory(store.GetDirectory(key))
+				if err != nil {
+					return false, nil, err
+				}
+
+				// Now that the directory is created, create the key
+				if _, err := s.client.Create(key, string(value), 0); err != nil {
+					return false, nil, err
+				}
+			}
+		}
 	}
 	if err != nil {
 		if etcdError, ok := err.(*etcd.EtcdError); ok {

--- a/store/store.go
+++ b/store/store.go
@@ -77,7 +77,8 @@ type Store interface {
 	// DeleteTree deletes a range of keys under a given directory
 	DeleteTree(directory string) error
 
-	// Atomic operation on a single value
+	// Atomic CAS operation on a single value.
+	// Pass previous = nil to create a new key.
 	AtomicPut(key string, value []byte, previous *KVPair, options *WriteOptions) (bool, *KVPair, error)
 
 	// Atomic delete of a single value

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -15,6 +15,7 @@ func RunTestStore(t *testing.T, kv store.Store, backup store.Store) {
 	testWatch(t, kv)
 	testWatchTree(t, kv)
 	testAtomicPut(t, kv)
+	testAtomicPutCreate(t, kv)
 	testAtomicDelete(t, kv)
 	testLockUnlock(t, kv)
 	testPutEphemeral(t, kv, backup)
@@ -187,11 +188,40 @@ func testAtomicPut(t *testing.T, kv store.Store) {
 	assert.NoError(t, err)
 	assert.True(t, success)
 
-	// This CAS should fail
+	// This CAS should fail, key exists.
 	pair.LastIndex = 0
 	success, _, err = kv.AtomicPut("hello", []byte("WORLDWORLD"), pair, nil)
 	assert.Error(t, err)
 	assert.False(t, success)
+}
+
+func testAtomicPutCreate(t *testing.T, kv store.Store) {
+	key := "foo/bar"
+	value := []byte("world")
+
+	// AtomicPut the key, uninitialized LastIndex means create the key.
+	prev := &store.KVPair{Key: key}
+	success, _, err := kv.AtomicPut(key, value, prev, nil)
+	assert.NoError(t, err)
+
+	// Get should return the value and an incremented index
+	pair, err := kv.Get(key)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair) {
+		assert.NotNil(t, pair.Value)
+	}
+	assert.Equal(t, pair.Value, value)
+	assert.NotEqual(t, pair.LastIndex, 0)
+
+	// Attempting to create again should fail.
+	success, _, err = kv.AtomicPut(key, value, prev, nil)
+	assert.Error(t, err)
+	assert.False(t, success)
+
+	// This CAS should succeed
+	success, _, err = kv.AtomicPut(key, []byte("WORLD"), pair, nil)
+	assert.NoError(t, err)
+	assert.True(t, success)
 }
 
 func testAtomicDelete(t *testing.T, kv store.Store) {

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -178,7 +178,7 @@ func testAtomicPut(t *testing.T, kv store.Store) {
 	assert.Equal(t, pair.Value, value)
 	assert.NotEqual(t, pair.LastIndex, 0)
 
-	// This CAS should fail: no previous
+	// This CAS should fail: previous exists.
 	success, _, err := kv.AtomicPut("hello", []byte("WORLD"), nil, nil)
 	assert.Error(t, err)
 	assert.False(t, success)
@@ -196,13 +196,15 @@ func testAtomicPut(t *testing.T, kv store.Store) {
 }
 
 func testAtomicPutCreate(t *testing.T, kv store.Store) {
-	key := "foo/bar"
-	value := []byte("world")
+	// Use a key in a new directory to ensure Stores will create directories
+	// that don't yet exist.
+	key := "put/create"
+	value := []byte("putcreate")
 
-	// AtomicPut the key, uninitialized LastIndex means create the key.
-	prev := &store.KVPair{Key: key}
-	success, _, err := kv.AtomicPut(key, value, prev, nil)
+	// AtomicPut the key, previous = nil indicates create.
+	success, _, err := kv.AtomicPut(key, value, nil, nil)
 	assert.NoError(t, err)
+	assert.True(t, success)
 
 	// Get should return the value and an incremented index
 	pair, err := kv.Get(key)
@@ -211,17 +213,20 @@ func testAtomicPutCreate(t *testing.T, kv store.Store) {
 		assert.NotNil(t, pair.Value)
 	}
 	assert.Equal(t, pair.Value, value)
-	assert.NotEqual(t, pair.LastIndex, 0)
 
 	// Attempting to create again should fail.
-	success, _, err = kv.AtomicPut(key, value, prev, nil)
+	success, _, err = kv.AtomicPut(key, value, nil, nil)
 	assert.Error(t, err)
 	assert.False(t, success)
 
-	// This CAS should succeed
-	success, _, err = kv.AtomicPut(key, []byte("WORLD"), pair, nil)
+	// This CAS should succeed, since it has the value from Get()
+	success, _, err = kv.AtomicPut(key, []byte("PUTCREATE"), pair, nil)
 	assert.NoError(t, err)
 	assert.True(t, success)
+
+	// Delete the key, ensures runs of the test don't interfere with each other.
+	err = kv.DeleteTree("put")
+	assert.NoError(t, err)
 }
 
 func testAtomicDelete(t *testing.T, kv store.Store) {


### PR DESCRIPTION
We need a way to put a new key, value pair into the datastore, ensuring it doesn't overwrite anything existing.

Libkv only defines an `AtomicPut` operation for setting a key in a way that ensures we don't trample another write.

However, in `etcd` the consistent operations of "update" and "create" are distinct (`CompareAndSwap` and `Create` in the go API).

In this PR, we modify `AtomicPut` to interpret LastIndex == 0 (e.g. newly initialized) as a `Create`.  This allows the user to put a new key, ensuring that it is not overwriting another write.

I'm speculating on the API here, since it isn't directly documented what the expectation is for `AtomicPut`.  Another way to accomplish this requirement is to define a separate call `AtomicCreate` which takes no `previous` value.  Can one of the maintainers comment on this?