### PR TITLE
Allow full URLs in connection specification, with etcd tests

### DIFF
--- a/store/etcd/etcd_test.go
+++ b/store/etcd/etcd_test.go
@@ -26,6 +26,40 @@ func makeEtcdClient(t *testing.T) store.Store {
 	return kv
 }
 
+func TestEtcdConnection(t *testing.T) {
+	kv, err := New(
+		[]string{"localhost:4001"},
+		&store.Config{
+			ConnectionTimeout: 3 * time.Second,
+			EphemeralTTL:      2 * time.Second,
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("Could not construct kv store: %v", err)
+	}
+
+	if err := kv.Put("/foo", []byte("bar"), nil); err != nil {
+		t.Fatalf("Could not put: %v", err)
+	}
+
+	kv, err = New(
+		[]string{"http://localhost:4001"},
+		&store.Config{
+			ConnectionTimeout: 3 * time.Second,
+			EphemeralTTL:      2 * time.Second,
+		},
+	)
+
+	if err != nil {
+		t.Fatalf("Could not construct kv store: %v", err)
+	}
+
+	if err := kv.Put("/foo", []byte("bar"), nil); err != nil {
+		t.Fatalf("Could not put: %v", err)
+	}
+}
+
 func TestEtcdStore(t *testing.T) {
 	kv := makeEtcdClient(t)
 	backup := makeEtcdClient(t)

--- a/store/helpers.go
+++ b/store/helpers.go
@@ -1,13 +1,23 @@
 package store
 
 import (
+	"net/url"
 	"strings"
 )
 
 // CreateEndpoints creates a list of endpoints given the right scheme
 func CreateEndpoints(addrs []string, scheme string) (entries []string) {
 	for _, addr := range addrs {
-		entries = append(entries, scheme+"://"+addr)
+		// Note that in the event of a bad URL that's still parseable (such as
+		// localhost:1234) the scheme will equal the hostname. We check against the
+		// supplied scheme to ensure we at least tried to handle this
+		// appropriately.
+		u, err := url.Parse(addr)
+		if err != nil || (u != nil && u.Scheme != scheme) {
+			entries = append(entries, scheme+"://"+addr)
+		} else {
+			entries = append(entries, addr)
+		}
 	}
 	return entries
 }


### PR DESCRIPTION
This allow specifications like such:

`http://localhost:1234` (the new behavior, previously would set `http://http://localhost:1234`
and
`localhost:1234` (the existing behavior)
but not
`https://localhost:1234` -- to do this would require full URLs, which I don't think work for zookeeper.

I don't have tests for consul and zk because I don't really have the infra to do so.

HTH!

-Erik