### PR TITLE
Change Heartbeat/Ephemeral combination to use a single TTL field

### DIFF
--- a/store/consul/consul_test.go
+++ b/store/consul/consul_test.go
@@ -16,7 +16,6 @@ func makeConsulClient(t *testing.T) store.Store {
 		[]string{client},
 		&store.Config{
 			ConnectionTimeout: 3 * time.Second,
-			EphemeralTTL:      2 * time.Second,
 		},
 	)
 
@@ -43,7 +42,7 @@ func TestGetActiveSession(t *testing.T) {
 	value := []byte("bar")
 
 	// Put the first key with the Ephemeral flag
-	err := kv.Put(key, value, &store.WriteOptions{Ephemeral: true})
+	err := kv.Put(key, value, &store.WriteOptions{TTL: 2 * time.Second})
 	assert.NoError(t, err)
 
 	// Session should not be empty

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -14,8 +14,7 @@ import (
 // Etcd is the receiver type for the
 // Store interface
 type Etcd struct {
-	client       *etcd.Client
-	ephemeralTTL time.Duration
+	client *etcd.Client
 }
 
 type etcdLock struct {
@@ -48,9 +47,6 @@ func New(addrs []string, options *store.Config) (store.Store, error) {
 		}
 		if options.ConnectionTimeout != 0 {
 			s.setTimeout(options.ConnectionTimeout)
-		}
-		if options.EphemeralTTL != 0 {
-			s.setEphemeralTTL(options.EphemeralTTL)
 		}
 	}
 
@@ -91,12 +87,6 @@ func (s *Etcd) setTLS(tls *tls.Config) {
 // setTimeout sets the timeout used for connecting to the store
 func (s *Etcd) setTimeout(time time.Duration) {
 	s.client.SetDialTimeout(time)
-}
-
-// setEphemeralHeartbeat sets the heartbeat value to notify
-// that a node is alive
-func (s *Etcd) setEphemeralTTL(time time.Duration) {
-	s.ephemeralTTL = time
 }
 
 // createDirectory creates the entire path for a directory
@@ -140,8 +130,8 @@ func (s *Etcd) Put(key string, value []byte, opts *store.WriteOptions) error {
 
 	// Default TTL = 0 means no expiration
 	var ttl uint64
-	if opts != nil && opts.Ephemeral {
-		ttl = uint64(s.ephemeralTTL.Seconds())
+	if opts != nil && opts.TTL > 0 {
+		ttl = uint64(opts.TTL.Seconds())
 	}
 
 	if _, err := s.client.Set(key, string(value), ttl); err != nil {

--- a/store/etcd/etcd_test.go
+++ b/store/etcd/etcd_test.go
@@ -15,7 +15,6 @@ func makeEtcdClient(t *testing.T) store.Store {
 		[]string{client},
 		&store.Config{
 			ConnectionTimeout: 3 * time.Second,
-			EphemeralTTL:      2 * time.Second,
 		},
 	)
 

--- a/store/store.go
+++ b/store/store.go
@@ -39,7 +39,6 @@ var (
 type Config struct {
 	TLS               *tls.Config
 	ConnectionTimeout time.Duration
-	EphemeralTTL      time.Duration
 }
 
 // Store represents the backend K/V storage
@@ -97,8 +96,7 @@ type KVPair struct {
 
 // WriteOptions contains optional request parameters
 type WriteOptions struct {
-	Heartbeat time.Duration
-	Ephemeral bool
+	TTL time.Duration
 }
 
 // LockOptions contains optional request parameters

--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -114,8 +114,8 @@ func (s *Zookeeper) Put(key string, value []byte, opts *store.WriteOptions) erro
 	}
 
 	if !exists {
-		if opts != nil && opts.Ephemeral {
-			s.createFullPath(store.SplitKey(key), opts.Ephemeral)
+		if opts != nil && opts.TTL > 0 {
+			s.createFullPath(store.SplitKey(key), true)
 		} else {
 			s.createFullPath(store.SplitKey(key), false)
 		}

--- a/store/zookeeper/zookeeper_test.go
+++ b/store/zookeeper/zookeeper_test.go
@@ -15,7 +15,6 @@ func makeZkClient(t *testing.T) store.Store {
 		[]string{client},
 		&store.Config{
 			ConnectionTimeout: 3 * time.Second,
-			EphemeralTTL:      2 * time.Second,
 		},
 	)
 

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -18,13 +18,13 @@ func RunTestStore(t *testing.T, kv store.Store, backup store.Store) {
 	testAtomicPutCreate(t, kv)
 	testAtomicDelete(t, kv)
 	testLockUnlock(t, kv)
-	testPutEphemeral(t, kv, backup)
+	testPutTTL(t, kv, backup)
 	testList(t, kv)
 	testDeleteTree(t, kv)
 }
 
 func testPutGetDeleteExists(t *testing.T, kv store.Store) {
-	key := "foo"
+	key := "testfoo"
 	value := []byte("bar")
 
 	// Put the key
@@ -280,7 +280,7 @@ func testLockUnlock(t *testing.T, kv store.Store) {
 	value := []byte("bar")
 
 	// We should be able to create a new lock on key
-	lock, err := kv.NewLock(key, &store.LockOptions{Value: value})
+	lock, err := kv.NewLock(key, &store.LockOptions{Value: value, TTL: 2 * time.Second})
 	assert.NoError(t, err)
 	assert.NotNil(t, lock)
 
@@ -317,7 +317,7 @@ func testLockUnlock(t *testing.T, kv store.Store) {
 	assert.NotEqual(t, pair.LastIndex, 0)
 }
 
-func testPutEphemeral(t *testing.T, kv store.Store, otherConn store.Store) {
+func testPutTTL(t *testing.T, kv store.Store, otherConn store.Store) {
 	firstKey := "first"
 	firstValue := []byte("foo")
 
@@ -325,11 +325,11 @@ func testPutEphemeral(t *testing.T, kv store.Store, otherConn store.Store) {
 	secondValue := []byte("bar")
 
 	// Put the first key with the Ephemeral flag
-	err := otherConn.Put(firstKey, firstValue, &store.WriteOptions{Ephemeral: true})
+	err := otherConn.Put(firstKey, firstValue, &store.WriteOptions{TTL: 2 * time.Second})
 	assert.NoError(t, err)
 
 	// Put a second key with the Ephemeral flag
-	err = otherConn.Put(secondKey, secondValue, &store.WriteOptions{Ephemeral: true})
+	err = otherConn.Put(secondKey, secondValue, &store.WriteOptions{TTL: 2 * time.Second})
 	assert.NoError(t, err)
 
 	// Get on firstKey should work


### PR DESCRIPTION
Drops the `Ephemeral`/`Heartbeat` config field combination to use a single `TTL` field. Most of the stores are using `TTL`'s, so this is better overall.

fixes #23
replaces #24

Signed-off-by: Alexandre Beslic <abronan@docker.com>