### PR TITLE
Notify user of supported backend storage

### DIFF
--- a/libkv.go
+++ b/libkv.go
@@ -62,6 +62,10 @@
 package libkv
 
 import (
+	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/store/consul"
 	"github.com/docker/libkv/store/etcd"
@@ -78,6 +82,14 @@ var (
 		store.ETCD:   etcd.New,
 		store.ZK:     zookeeper.New,
 	}
+	supportedBackend = func() string {
+		keys := make([]string, 0, len(initializers))
+		for k := range initializers {
+			keys = append(keys, string(k))
+		}
+		sort.Strings(keys)
+		return strings.Join(keys, ", ")
+	}()
 )
 
 // NewStore creates a an instance of store
@@ -86,5 +98,5 @@ func NewStore(backend store.Backend, addrs []string, options *store.Config) (sto
 		return init(addrs, options)
 	}
 
-	return nil, store.ErrNotSupported
+	return nil, fmt.Errorf("%s %s", store.ErrNotSupported.Error(), supportedBackend)
 }

--- a/libkv_test.go
+++ b/libkv_test.go
@@ -77,4 +77,5 @@ func TestNewStoreUnsupported(t *testing.T) {
 	)
 	assert.Error(t, err)
 	assert.Nil(t, kv)
+	assert.Equal(t, "Backend storage not supported yet, please choose one of consul, etcd, zk", err.Error())
 }

--- a/store/store.go
+++ b/store/store.go
@@ -20,7 +20,7 @@ const (
 
 var (
 	// ErrNotSupported is thrown when the backend k/v store is not supported by libkv
-	ErrNotSupported = errors.New("Backend storage not supported yet, please choose another one")
+	ErrNotSupported = errors.New("Backend storage not supported yet, please choose one of")
 	// ErrNotImplemented is thrown when a method is not implemented by the current backend
 	ErrNotImplemented = errors.New("Call not implemented in current backend")
 	// ErrNotReachable is thrown when the API cannot be reached for issuing common store operations


### PR DESCRIPTION
Signed-off-by: Chun Chen <ramichen@tencent.com>

When I tried to start docker with `docker -d  --bip 192.168.1.0/16 -D -H tcp://0.0.0.0:2375 -H unix:///var/run/docker.sock --kv-store=Zookeeper:127.0.0.1:2181`, I got the error "Backend storage not supported yet, please choose another one". There isn't any docs in docker/libnetwork/libkv telling it's `zk` instead of `Zookeeper`. So I think it's better to make the error message self-explaining. 