### PR TITLE
Fix ZooKeeper backend suffix backslash key

### DIFF
--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -190,6 +190,9 @@ func (s *Consul) Put(key string, value []byte, opts *store.WriteOptions) error {
 
 // Delete a value at "key"
 func (s *Consul) Delete(key string) error {
+	if _, err := s.Get(key); err != nil {
+		return err
+	}
 	_, err := s.client.KV().Delete(s.normalize(key), nil)
 	return err
 }
@@ -234,6 +237,9 @@ func (s *Consul) List(directory string) ([]*store.KVPair, error) {
 
 // DeleteTree deletes a range of keys under a given directory
 func (s *Consul) DeleteTree(directory string) error {
+	if _, err := s.List(directory); err != nil {
+		return err
+	}
 	_, err := s.client.KV().DeleteTree(s.normalize(directory), nil)
 	return err
 }

--- a/store/consul/consul_test.go
+++ b/store/consul/consul_test.go
@@ -35,6 +35,7 @@ func TestConsulStore(t *testing.T) {
 	testutils.RunTestWatch(t, kv)
 	testutils.RunTestLock(t, kv)
 	testutils.RunTestTTL(t, kv, backup)
+	testutils.RunCleanup(t, kv)
 }
 
 func TestGetActiveSession(t *testing.T) {

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -160,6 +160,9 @@ func (s *Etcd) Put(key string, value []byte, opts *store.WriteOptions) error {
 // Delete a value at "key"
 func (s *Etcd) Delete(key string) error {
 	_, err := s.client.Delete(store.Normalize(key), false)
+	if isKeyNotFoundError(err) {
+		return store.ErrKeyNotFound
+	}
 	return err
 }
 
@@ -366,6 +369,9 @@ func (s *Etcd) List(directory string) ([]*store.KVPair, error) {
 // DeleteTree deletes a range of keys under a given directory
 func (s *Etcd) DeleteTree(directory string) error {
 	_, err := s.client.Delete(store.Normalize(directory), true)
+	if isKeyNotFoundError(err) {
+		return store.ErrKeyNotFound
+	}
 	return err
 }
 

--- a/store/etcd/etcd_test.go
+++ b/store/etcd/etcd_test.go
@@ -34,4 +34,5 @@ func TestEtcdStore(t *testing.T) {
 	testutils.RunTestWatch(t, kv)
 	testutils.RunTestLock(t, kv)
 	testutils.RunTestTTL(t, kv, backup)
+	testutils.RunCleanup(t, kv)
 }

--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -9,9 +9,6 @@ import (
 )
 
 const (
-	// SOH control character
-	SOH = "\x01"
-
 	defaultTimeout = 10 * time.Second
 )
 
@@ -69,12 +66,6 @@ func (s *Zookeeper) Get(key string) (pair *store.KVPair, err error) {
 		return nil, err
 	}
 
-	// FIXME handle very rare cases where Get returns the
-	// SOH control character instead of the actual value
-	if string(resp) == SOH {
-		return s.Get(s.normalize(key))
-	}
-
 	pair = &store.KVPair{
 		Key:       key,
 		Value:     resp,
@@ -90,10 +81,10 @@ func (s *Zookeeper) createFullPath(path []string, ephemeral bool) error {
 	for i := 1; i <= len(path); i++ {
 		newpath := "/" + strings.Join(path[:i], "/")
 		if i == len(path) && ephemeral {
-			_, err := s.client.Create(newpath, []byte{1}, zk.FlagEphemeral, zk.WorldACL(zk.PermAll))
+			_, err := s.client.Create(newpath, []byte{}, zk.FlagEphemeral, zk.WorldACL(zk.PermAll))
 			return err
 		}
-		_, err := s.client.Create(newpath, []byte{1}, 0, zk.WorldACL(zk.PermAll))
+		_, err := s.client.Create(newpath, []byte{}, 0, zk.WorldACL(zk.PermAll))
 		if err != nil {
 			// Skip if node already exists
 			if err != zk.ErrNodeExists {

--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -60,7 +60,7 @@ func (s *Zookeeper) setTimeout(time time.Duration) {
 // Get the value at "key", returns the last modified index
 // to use in conjunction to Atomic calls
 func (s *Zookeeper) Get(key string) (pair *store.KVPair, err error) {
-	resp, meta, err := s.client.Get(store.Normalize(key))
+	resp, meta, err := s.client.Get(s.normalize(key))
 
 	if err != nil {
 		if err == zk.ErrNoNode {
@@ -72,7 +72,7 @@ func (s *Zookeeper) Get(key string) (pair *store.KVPair, err error) {
 	// FIXME handle very rare cases where Get returns the
 	// SOH control character instead of the actual value
 	if string(resp) == SOH {
-		return s.Get(store.Normalize(key))
+		return s.Get(s.normalize(key))
 	}
 
 	pair = &store.KVPair{
@@ -106,7 +106,7 @@ func (s *Zookeeper) createFullPath(path []string, ephemeral bool) error {
 
 // Put a value at "key"
 func (s *Zookeeper) Put(key string, value []byte, opts *store.WriteOptions) error {
-	fkey := store.Normalize(key)
+	fkey := s.normalize(key)
 
 	exists, err := s.Exists(key)
 	if err != nil {
@@ -115,9 +115,9 @@ func (s *Zookeeper) Put(key string, value []byte, opts *store.WriteOptions) erro
 
 	if !exists {
 		if opts != nil && opts.TTL > 0 {
-			s.createFullPath(store.SplitKey(key), true)
+			s.createFullPath(store.SplitKey(strings.TrimSuffix(key, "/")), true)
 		} else {
-			s.createFullPath(store.SplitKey(key), false)
+			s.createFullPath(store.SplitKey(strings.TrimSuffix(key, "/")), false)
 		}
 	}
 
@@ -127,13 +127,13 @@ func (s *Zookeeper) Put(key string, value []byte, opts *store.WriteOptions) erro
 
 // Delete a value at "key"
 func (s *Zookeeper) Delete(key string) error {
-	err := s.client.Delete(store.Normalize(key), -1)
+	err := s.client.Delete(s.normalize(key), -1)
 	return err
 }
 
 // Exists checks if the key exists inside the store
 func (s *Zookeeper) Exists(key string) (bool, error) {
-	exists, _, err := s.client.Exists(store.Normalize(key))
+	exists, _, err := s.client.Exists(s.normalize(key))
 	if err != nil {
 		return false, err
 	}
@@ -161,7 +161,7 @@ func (s *Zookeeper) Watch(key string, stopCh <-chan struct{}) (<-chan *store.KVP
 		// to listening to any event that may occur on that key
 		watchCh <- pair
 		for {
-			_, _, eventCh, err := s.client.GetW(store.Normalize(key))
+			_, _, eventCh, err := s.client.GetW(s.normalize(key))
 			if err != nil {
 				return
 			}
@@ -205,7 +205,7 @@ func (s *Zookeeper) WatchTree(directory string, stopCh <-chan struct{}) (<-chan 
 		watchCh <- entries
 
 		for {
-			_, _, eventCh, err := s.client.ChildrenW(store.Normalize(directory))
+			_, _, eventCh, err := s.client.ChildrenW(s.normalize(directory))
 			if err != nil {
 				return
 			}
@@ -228,7 +228,7 @@ func (s *Zookeeper) WatchTree(directory string, stopCh <-chan struct{}) (<-chan 
 
 // List child nodes of a given directory
 func (s *Zookeeper) List(directory string) ([]*store.KVPair, error) {
-	keys, stat, err := s.client.Children(store.Normalize(directory))
+	keys, stat, err := s.client.Children(s.normalize(directory))
 	if err != nil {
 		if err == zk.ErrNoNode {
 			return nil, store.ErrKeyNotFound
@@ -240,7 +240,7 @@ func (s *Zookeeper) List(directory string) ([]*store.KVPair, error) {
 
 	// FIXME Costly Get request for each child key..
 	for _, key := range keys {
-		pair, err := s.Get(directory + store.Normalize(key))
+		pair, err := s.Get(strings.TrimSuffix(directory, "/") + s.normalize(key))
 		if err != nil {
 			// If node is not found: List is out of date, retry
 			if err == zk.ErrNoNode {
@@ -270,7 +270,7 @@ func (s *Zookeeper) DeleteTree(directory string) error {
 
 	for _, pair := range pairs {
 		reqs = append(reqs, &zk.DeleteRequest{
-			Path:    store.Normalize(directory + "/" + pair.Key),
+			Path:    s.normalize(directory + "/" + pair.Key),
 			Version: -1,
 		})
 	}
@@ -285,7 +285,7 @@ func (s *Zookeeper) AtomicPut(key string, value []byte, previous *store.KVPair, 
 
 	var lastIndex uint64
 	if previous != nil {
-		meta, err := s.client.Set(store.Normalize(key), value, int32(previous.LastIndex))
+		meta, err := s.client.Set(s.normalize(key), value, int32(previous.LastIndex))
 		if err != nil {
 			// Compare Failed
 			if err == zk.ErrBadVersion {
@@ -296,7 +296,7 @@ func (s *Zookeeper) AtomicPut(key string, value []byte, previous *store.KVPair, 
 		lastIndex = uint64(meta.Version)
 	} else {
 		// Interpret previous == nil as create operation.
-		_, err := s.client.Create(store.Normalize(key), value, 0, zk.WorldACL(zk.PermAll))
+		_, err := s.client.Create(s.normalize(key), value, 0, zk.WorldACL(zk.PermAll))
 		if err != nil {
 			// Zookeeper will complain if the directory doesn't exist.
 			if err == zk.ErrNoNode {
@@ -307,7 +307,7 @@ func (s *Zookeeper) AtomicPut(key string, value []byte, previous *store.KVPair, 
 					// Failed to create the directory.
 					return false, nil, err
 				}
-				if _, err := s.client.Create(store.Normalize(key), value, 0, zk.WorldACL(zk.PermAll)); err != nil {
+				if _, err := s.client.Create(s.normalize(key), value, 0, zk.WorldACL(zk.PermAll)); err != nil {
 					return false, nil, err
 				}
 
@@ -336,7 +336,7 @@ func (s *Zookeeper) AtomicDelete(key string, previous *store.KVPair) (bool, erro
 		return false, store.ErrPreviousNotSpecified
 	}
 
-	err := s.client.Delete(store.Normalize(key), int32(previous.LastIndex))
+	err := s.client.Delete(s.normalize(key), int32(previous.LastIndex))
 	if err != nil {
 		if err == zk.ErrBadVersion {
 			return false, store.ErrKeyModified
@@ -360,9 +360,9 @@ func (s *Zookeeper) NewLock(key string, options *store.LockOptions) (lock store.
 
 	lock = &zookeeperLock{
 		client: s.client,
-		key:    store.Normalize(key),
+		key:    s.normalize(key),
 		value:  value,
-		lock:   zk.NewLock(s.client, store.Normalize(key), zk.WorldACL(zk.PermAll)),
+		lock:   zk.NewLock(s.client, s.normalize(key), zk.WorldACL(zk.PermAll)),
 	}
 
 	return lock, err
@@ -393,4 +393,10 @@ func (l *zookeeperLock) Unlock() error {
 // Close closes the client connection
 func (s *Zookeeper) Close() {
 	s.client.Close()
+}
+
+// Normalize the key for usage in Zookeeper
+func (s *Zookeeper) normalize(key string) string {
+	key = store.Normalize(key)
+	return strings.TrimSuffix(key, "/")
 }

--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -119,6 +119,9 @@ func (s *Zookeeper) Put(key string, value []byte, opts *store.WriteOptions) erro
 // Delete a value at "key"
 func (s *Zookeeper) Delete(key string) error {
 	err := s.client.Delete(s.normalize(key), -1)
+	if err == zk.ErrNoNode {
+		return store.ErrKeyNotFound
+	}
 	return err
 }
 

--- a/store/zookeeper/zookeeper_test.go
+++ b/store/zookeeper/zookeeper_test.go
@@ -34,5 +34,5 @@ func TestZkStore(t *testing.T) {
 	testutils.RunTestWatch(t, kv)
 	testutils.RunTestLock(t, kv)
 	testutils.RunTestTTL(t, kv, backup)
-
+	testutils.RunCleanup(t, kv)
 }

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -50,10 +50,10 @@ func testPutGetDeleteExists(t *testing.T, kv store.Store) {
 
 	value := []byte("bar")
 	for _, key := range []string{
-		"testfoo",
-		"testfoo/",
-		"testfoo/testbar/",
-		"testfoo/testbar/testfoobar",
+		"testPutGetDeleteExists",
+		"testPutGetDeleteExists/",
+		"testPutGetDeleteExists/testbar/",
+		"testPutGetDeleteExists/testbar/testfoobar",
 	} {
 		failMsg := fmt.Sprintf("Fail key %s", key)
 		// Put the key
@@ -91,7 +91,7 @@ func testPutGetDeleteExists(t *testing.T, kv store.Store) {
 }
 
 func testWatch(t *testing.T, kv store.Store) {
-	key := "hello"
+	key := "testWatch"
 	value := []byte("world")
 	newValue := []byte("world!")
 
@@ -148,15 +148,15 @@ func testWatch(t *testing.T, kv store.Store) {
 }
 
 func testWatchTree(t *testing.T, kv store.Store) {
-	dir := "tree"
+	dir := "testWatchTree"
 
-	node1 := "tree/node1"
+	node1 := "testWatchTree/node1"
 	value1 := []byte("node1")
 
-	node2 := "tree/node2"
+	node2 := "testWatchTree/node2"
 	value2 := []byte("node2")
 
-	node3 := "tree/node3"
+	node3 := "testWatchTree/node3"
 	value3 := []byte("node3")
 
 	err := kv.Put(node1, value1, nil)
@@ -202,7 +202,7 @@ func testWatchTree(t *testing.T, kv store.Store) {
 }
 
 func testAtomicPut(t *testing.T, kv store.Store) {
-	key := "hello"
+	key := "testAtomicPut"
 	value := []byte("world")
 
 	// Put the key
@@ -219,18 +219,18 @@ func testAtomicPut(t *testing.T, kv store.Store) {
 	assert.NotEqual(t, pair.LastIndex, 0)
 
 	// This CAS should fail: previous exists.
-	success, _, err := kv.AtomicPut("hello", []byte("WORLD"), nil, nil)
+	success, _, err := kv.AtomicPut(key, []byte("WORLD"), nil, nil)
 	assert.Error(t, err)
 	assert.False(t, success)
 
 	// This CAS should succeed
-	success, _, err = kv.AtomicPut("hello", []byte("WORLD"), pair, nil)
+	success, _, err = kv.AtomicPut(key, []byte("WORLD"), pair, nil)
 	assert.NoError(t, err)
 	assert.True(t, success)
 
 	// This CAS should fail, key exists.
 	pair.LastIndex = 0
-	success, _, err = kv.AtomicPut("hello", []byte("WORLDWORLD"), pair, nil)
+	success, _, err = kv.AtomicPut(key, []byte("WORLDWORLD"), pair, nil)
 	assert.Error(t, err)
 	assert.False(t, success)
 }
@@ -238,7 +238,7 @@ func testAtomicPut(t *testing.T, kv store.Store) {
 func testAtomicPutCreate(t *testing.T, kv store.Store) {
 	// Use a key in a new directory to ensure Stores will create directories
 	// that don't yet exist.
-	key := "put/create"
+	key := "testAtomicPutCreate/create"
 	value := []byte("putcreate")
 
 	// AtomicPut the key, previous = nil indicates create.
@@ -263,14 +263,10 @@ func testAtomicPutCreate(t *testing.T, kv store.Store) {
 	success, _, err = kv.AtomicPut(key, []byte("PUTCREATE"), pair, nil)
 	assert.NoError(t, err)
 	assert.True(t, success)
-
-	// Delete the key, ensures runs of the test don't interfere with each other.
-	err = kv.DeleteTree("put")
-	assert.NoError(t, err)
 }
 
 func testAtomicDelete(t *testing.T, kv store.Store) {
-	key := "atomic"
+	key := "testAtomicDelete"
 	value := []byte("world")
 
 	// Put the key
@@ -302,7 +298,7 @@ func testAtomicDelete(t *testing.T, kv store.Store) {
 }
 
 func testLockUnlock(t *testing.T, kv store.Store) {
-	key := "foo"
+	key := "testLockUnlock"
 	value := []byte("bar")
 
 	// We should be able to create a new lock on key
@@ -344,7 +340,7 @@ func testLockUnlock(t *testing.T, kv store.Store) {
 }
 
 func testPutTTL(t *testing.T, kv store.Store, otherConn store.Store) {
-	firstKey := "first"
+	firstKey := "testPutTTL"
 	firstValue := []byte("foo")
 
 	secondKey := "second"
@@ -386,12 +382,12 @@ func testPutTTL(t *testing.T, kv store.Store, otherConn store.Store) {
 }
 
 func testList(t *testing.T, kv store.Store) {
-	prefix := "nodes"
+	prefix := "testList"
 
-	firstKey := "nodes/first"
+	firstKey := "testList/first"
 	firstValue := []byte("first")
 
-	secondKey := "nodes/second"
+	secondKey := "testList/second"
 	secondValue := []byte("second")
 
 	// Put the first key
@@ -428,12 +424,12 @@ func testList(t *testing.T, kv store.Store) {
 }
 
 func testDeleteTree(t *testing.T, kv store.Store) {
-	prefix := "nodes"
+	prefix := "testDeleteTree"
 
-	firstKey := "nodes/first"
+	firstKey := "testDeleteTree/first"
 	firstValue := []byte("first")
 
-	secondKey := "nodes/second"
+	secondKey := "testDeleteTree/second"
 	secondValue := []byte("second")
 
 	// Put the first key
@@ -474,4 +470,25 @@ func testDeleteTree(t *testing.T, kv store.Store) {
 	pair, err = kv.Get(secondKey)
 	assert.Error(t, err)
 	assert.Nil(t, pair)
+}
+
+// RunCleanup cleans up keys introduced by the tests
+func RunCleanup(t *testing.T, kv store.Store) {
+	for _, key := range []string{
+		"testPutGetDeleteExists",
+		"testWatch",
+		"testWatchTree",
+		"testAtomicPut",
+		"testAtomicPutCreate",
+		"testAtomicDelete",
+		"testLockUnlock",
+		"testPutTTL",
+		"testList",
+		"testDeleteTree",
+	} {
+		err := kv.DeleteTree(key)
+		assert.True(t, err == nil || err == store.ErrKeyNotFound, fmt.Sprintf("failed to delete tree key %s: %v", key, err))
+		err = kv.Delete(key)
+		assert.True(t, err == nil || err == store.ErrKeyNotFound, fmt.Sprintf("failed to delete key %s: %v", key, err))
+	}
 }


### PR DESCRIPTION
Signed-off-by: Chun Chen <ramichen@tencent.com>

Keys with suffix backslash is not allowed for zookeeper.
```
chenchun@chenchun-T450:/usr/local/zookeeper-3.4.6$ bin/zkCli.sh
...
[zk: localhost:2181(CONNECTED) 0] ls /foo
[]
[zk: localhost:2181(CONNECTED) 1] ls /foo/
Command failed: java.lang.IllegalArgumentException: Path must not end with / character
[zk: localhost:2181(CONNECTED) 2] create /foo1/ ""
Command failed: java.lang.IllegalArgumentException: Path must not end with / character
[zk: localhost:2181(CONNECTED) 3] create /foo1 "" 
Created /foo1
[zk: localhost:2181(CONNECTED) 4] create //foo2 "" 
Command failed: java.lang.IllegalArgumentException: Invalid path string "//foo2" caused by empty node name specified @1
```
