### PR TITLE
Add Etcd TLS client auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ package main
 import (
 	"fmt"
 	"time"
-	
+
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 	log "github.com/Sirupsen/logrus"
@@ -61,6 +61,10 @@ func main() {
 ```
 
 You can find other usage examples for `libkv` under the `docker/swarm` or `docker/libnetwork` repositories.
+
+## TLS
+
+The etcd backend supports etcd servers that require TLS Client Authentication.  Zookeeper and Consul support are planned.  This feature is somewhat experimental and the store.ClientTLSConfig struct may change to accommodate the additional backends.
 
 ## Warning
 

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -37,12 +37,22 @@ const (
 func New(addrs []string, options *store.Config) (store.Store, error) {
 	s := &Etcd{}
 
-	entries := store.CreateEndpoints(addrs, "http")
-	s.client = etcd.NewClient(entries)
-
+	var entries []string
+	if options != nil && options.ClientTLS != nil {
+		entries = store.CreateEndpoints(addrs, "https")
+		var err error
+		s.client, err = etcd.NewTLSClient(entries, options.ClientTLS.CertFile, options.ClientTLS.KeyFile, options.ClientTLS.CACertFile)
+		if err != nil {
+			return s, err
+		}
+	} else {
+		entries = store.CreateEndpoints(addrs, "http")
+		s.client = etcd.NewClient(entries)
+	}
 	// Set options
 	if options != nil {
-		if options.TLS != nil {
+		if options.TLS != nil && options.ClientTLS == nil {
+			// NewTLSClient already does this.
 			s.setTLS(options.TLS)
 		}
 		if options.ConnectionTimeout != 0 {

--- a/store/store.go
+++ b/store/store.go
@@ -39,6 +39,15 @@ var (
 type Config struct {
 	TLS               *tls.Config
 	ConnectionTimeout time.Duration
+	ClientTLS         *ClientTLSConfig
+}
+
+// ClientTLSConfig contains data for a Client TLS configuration in the form
+//  the etcd client wants it.  Eventually we'll adapt it for ZK and Consul.
+type ClientTLSConfig struct {
+	CertFile   string
+	KeyFile    string
+	CACertFile string // Really should be []string, but etcd...
 }
 
 // Store represents the backend K/V storage


### PR DESCRIPTION
This PR adds support for TLS Client Auth in the etcd backend.  It addresses Issue #43.

It adds an additional structure to store.Config, ClientTLS, which is a pointer to a new struct type, ClientTLSConfig, which contains paths to TLS cert, key, and CA Cert.  CA Certs perhaps should be a list of CA cert files, but the etcd client only adds the first one anyway.  This may have to be revised when ZK and Consul support gets added, which is on our roadmap; however, the etcd client scratches our immediate itch.

The way it works is that when we create a new etcd client, if the ClientTLS field in Config is not nil, instead of using etcd.NewClient() we use etcd.NewTLSClient() to get the etcd client.  This has the side effect of creating its own http.Transport object, so we skip the bit in the libkv method that does that if TLS is set.  This may need to be more sophisticated, if there's some use case where the actual TLS Config needs to get through to a TLS-Client-Auth backend.  As it is I pretty much did the simplest thing that would work for my use-case, which is that etcd is requiring client certificates to connect to it.