### PR TITLE
Refactor libkv to not directly import storage backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For example, you can use it to store your metadata or for service discovery to r
 
 You can also easily implement a generic *Leader Election* on top of it (see the [swarm/leadership](https://github.com/docker/swarm/tree/master/leadership) package).
 
-As of now, `libkv` offers support for `Consul`, `Etcd` and `Zookeeper`.
+As of now, `libkv` offers support for `Consul`, `Etcd`, `Zookeeper` and `BoltDB`.
 
 ## Example of usage
 
@@ -24,11 +24,17 @@ package main
 import (
 	"fmt"
 	"time"
-	
+
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
+	"github.com/docker/libkv/store/consul"
 	log "github.com/Sirupsen/logrus"
 )
+
+func init() {
+	// Register consul store to libkv
+	consul.Register()
+}
 
 func main() {
 	client := "localhost:8500"

--- a/libkv.go
+++ b/libkv.go
@@ -67,10 +67,6 @@ import (
 	"strings"
 
 	"github.com/docker/libkv/store"
-	"github.com/docker/libkv/store/boltdb"
-	"github.com/docker/libkv/store/consul"
-	"github.com/docker/libkv/store/etcd"
-	"github.com/docker/libkv/store/zookeeper"
 )
 
 // Initialize creates a new Store object, initializing the client
@@ -78,12 +74,8 @@ type Initialize func(addrs []string, options *store.Config) (store.Store, error)
 
 var (
 	// Backend initializers
-	initializers = map[store.Backend]Initialize{
-		store.CONSUL: consul.New,
-		store.ETCD:   etcd.New,
-		store.ZK:     zookeeper.New,
-		store.BOLTDB: boltdb.New,
-	}
+	initializers = make(map[store.Backend]Initialize)
+
 	supportedBackend = func() string {
 		keys := make([]string, 0, len(initializers))
 		for k := range initializers {
@@ -101,4 +93,9 @@ func NewStore(backend store.Backend, addrs []string, options *store.Config) (sto
 	}
 
 	return nil, fmt.Errorf("%s %s", store.ErrNotSupported.Error(), supportedBackend)
+}
+
+// AddStore adds a new store backend to libkv
+func AddStore(store store.Backend, init Initialize) {
+	initializers[store] = init
 }

--- a/libkv_test.go
+++ b/libkv_test.go
@@ -5,65 +5,8 @@ import (
 	"time"
 
 	"github.com/docker/libkv/store"
-	"github.com/docker/libkv/store/consul"
-	"github.com/docker/libkv/store/etcd"
-	"github.com/docker/libkv/store/zookeeper"
 	"github.com/stretchr/testify/assert"
 )
-
-func TestNewStoreConsul(t *testing.T) {
-	client := "localhost:8500"
-
-	kv, err := NewStore(
-		store.CONSUL,
-		[]string{client},
-		&store.Config{
-			ConnectionTimeout: 10 * time.Second,
-		},
-	)
-	assert.NoError(t, err)
-	assert.NotNil(t, kv)
-
-	if _, ok := kv.(*consul.Consul); !ok {
-		t.Fatal("Error while initializing store consul")
-	}
-}
-
-func TestNewStoreEtcd(t *testing.T) {
-	client := "localhost:4001"
-
-	kv, err := NewStore(
-		store.ETCD,
-		[]string{client},
-		&store.Config{
-			ConnectionTimeout: 10 * time.Second,
-		},
-	)
-	assert.NoError(t, err)
-	assert.NotNil(t, kv)
-
-	if _, ok := kv.(*etcd.Etcd); !ok {
-		t.Fatal("Error while initializing store etcd")
-	}
-}
-
-func TestNewStoreZookeeper(t *testing.T) {
-	client := "localhost:2181"
-
-	kv, err := NewStore(
-		store.ZK,
-		[]string{client},
-		&store.Config{
-			ConnectionTimeout: 10 * time.Second,
-		},
-	)
-	assert.NoError(t, err)
-	assert.NotNil(t, kv)
-
-	if _, ok := kv.(*zookeeper.Zookeeper); !ok {
-		t.Fatal("Error while initializing store zookeeper")
-	}
-}
 
 func TestNewStoreUnsupported(t *testing.T) {
 	client := "localhost:9999"
@@ -77,5 +20,5 @@ func TestNewStoreUnsupported(t *testing.T) {
 	)
 	assert.Error(t, err)
 	assert.Nil(t, kv)
-	assert.Equal(t, "Backend storage not supported yet, please choose one of boltdb, consul, etcd, zk", err.Error())
+	assert.Equal(t, "Backend storage not supported yet, please choose one of ", err.Error())
 }

--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/boltdb/bolt"
+	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 )
 
@@ -34,6 +35,11 @@ type BoltDB struct {
 const (
 	libkvmetadatalen = 8
 )
+
+// Register registers boltdb to libkv
+func Register() {
+	libkv.AddStore(store.BOLTDB, New)
+}
 
 // New opens a new BoltDB connection to the specified path and bucket
 func New(endpoints []string, options *store.Config) (store.Store, error) {

--- a/store/boltdb/boltdb_test.go
+++ b/store/boltdb/boltdb_test.go
@@ -4,8 +4,10 @@ import (
 	"os"
 	"testing"
 
+	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/testutils"
+	"github.com/stretchr/testify/assert"
 )
 
 func makeBoltDBClient(t *testing.T) store.Store {
@@ -16,6 +18,24 @@ func makeBoltDBClient(t *testing.T) store.Store {
 	}
 
 	return kv
+}
+
+func TestRegister(t *testing.T) {
+	Register()
+
+	kv, err := libkv.NewStore(
+		store.BOLTDB,
+		[]string{"/tmp/not_exist_dir/__boltdbtest"},
+		&store.Config{Bucket: "boltDBTest"},
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+
+	if _, ok := kv.(*BoltDB); !ok {
+		t.Fatal("Error registering and initializing boltDB")
+	}
+
+	_ = os.Remove("/tmp/not_exist_dir/__boltdbtest")
 }
 
 func TestBoldDBStore(t *testing.T) {

--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 	api "github.com/hashicorp/consul/api"
 )
@@ -35,6 +36,11 @@ type Consul struct {
 
 type consulLock struct {
 	lock *api.Lock
+}
+
+// Register registers consul to libkv
+func Register() {
+	libkv.AddStore(store.CONSUL, New)
 }
 
 // New creates a new Consul client given a list

--- a/store/consul/consul_test.go
+++ b/store/consul/consul_test.go
@@ -4,13 +4,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
+var (
+	client = "localhost:8500"
+)
+
 func makeConsulClient(t *testing.T) store.Store {
-	client := "localhost:8500"
 
 	kv, err := New(
 		[]string{client},
@@ -24,6 +28,18 @@ func makeConsulClient(t *testing.T) store.Store {
 	}
 
 	return kv
+}
+
+func TestRegister(t *testing.T) {
+	Register()
+
+	kv, err := libkv.NewStore(store.CONSUL, []string{client}, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+
+	if _, ok := kv.(*Consul); !ok {
+		t.Fatal("Error registering and initializing consul")
+	}
 }
 
 func TestConsulStore(t *testing.T) {

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	etcd "github.com/coreos/go-etcd/etcd"
+	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 )
 
@@ -31,6 +32,11 @@ const (
 	defaultLockTTL    = 20 * time.Second
 	defaultUpdateTime = 5 * time.Second
 )
+
+// Register registers etcd to libkv
+func Register() {
+	libkv.AddStore(store.ETCD, New)
+}
 
 // New creates a new Etcd client given a list
 // of endpoints and an optional tls config

--- a/store/etcd/etcd_test.go
+++ b/store/etcd/etcd_test.go
@@ -4,13 +4,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	client = "localhost:4001"
 )
 
 func makeEtcdClient(t *testing.T) store.Store {
-	client := "localhost:4001"
-
 	kv, err := New(
 		[]string{client},
 		&store.Config{
@@ -23,6 +27,18 @@ func makeEtcdClient(t *testing.T) store.Store {
 	}
 
 	return kv
+}
+
+func TestRegister(t *testing.T) {
+	Register()
+
+	kv, err := libkv.NewStore(store.ETCD, []string{client}, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+
+	if _, ok := kv.(*Etcd); !ok {
+		t.Fatal("Error registering and initializing etcd")
+	}
 }
 
 func TestEtcdStore(t *testing.T) {

--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 	zk "github.com/samuel/go-zookeeper/zk"
 )
@@ -24,6 +25,11 @@ type zookeeperLock struct {
 	lock   *zk.Lock
 	key    string
 	value  []byte
+}
+
+// Register registers zookeeper to libkv
+func Register() {
+	libkv.AddStore(store.ZK, New)
 }
 
 // New creates a new Zookeeper client given a

--- a/store/zookeeper/zookeeper_test.go
+++ b/store/zookeeper/zookeeper_test.go
@@ -4,13 +4,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 	"github.com/docker/libkv/testutils"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	client = "localhost:2181"
 )
 
 func makeZkClient(t *testing.T) store.Store {
-	client := "localhost:2181"
-
 	kv, err := New(
 		[]string{client},
 		&store.Config{
@@ -23,6 +27,18 @@ func makeZkClient(t *testing.T) store.Store {
 	}
 
 	return kv
+}
+
+func TestRegister(t *testing.T) {
+	Register()
+
+	kv, err := libkv.NewStore(store.ZK, []string{client}, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, kv)
+
+	if _, ok := kv.(*Zookeeper); !ok {
+		t.Fatal("Error registering and initializing zookeeper")
+	}
 }
 
 func TestZkStore(t *testing.T) {


### PR DESCRIPTION
fixes #49 

@mavenugo Is that what you had in mind? I managed to update libkv Godeps in swarm without boltDB thanks to this (see the `README`). If you have a better approach let me know :smile: 

Signed-off-by: Alexandre Beslic <abronan@docker.com>