### PR TITLE
Session renewal retry count for Consul versions not supporting Sessions

### DIFF
--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -18,12 +18,20 @@ const (
 	// time to check if the watched key has changed. This
 	// affects the minimum time it takes to cancel a watch.
 	DefaultWatchWaitTime = 15 * time.Second
+
+	// RenewSessionRetryMax is the number of time we should try
+	// to renew the session before giving up and throwing an error
+	RenewSessionRetryMax = 5
 )
 
 var (
 	// ErrMultipleEndpointsUnsupported is thrown when there are
 	// multiple endpoints specified for Consul
 	ErrMultipleEndpointsUnsupported = errors.New("consul does not support multiple endpoints")
+
+	// ErrSessionRenew is thrown when the session can't be
+	// renewed because the Consul version does not support sessions
+	ErrSessionRenew = errors.New("cannot set or renew session for ttl, unable to operate on sessions")
 )
 
 // Consul is the receiver type for the
@@ -98,7 +106,7 @@ func (s *Consul) normalize(key string) string {
 	return strings.TrimPrefix(key, "/")
 }
 
-func (s *Consul) refreshSession(pair *api.KVPair, ttl time.Duration) error {
+func (s *Consul) renewSession(pair *api.KVPair, ttl time.Duration) error {
 	// Check if there is any previous session with an active TTL
 	session, err := s.getActiveSession(pair.Key)
 	if err != nil {
@@ -133,10 +141,7 @@ func (s *Consul) refreshSession(pair *api.KVPair, ttl time.Duration) error {
 	}
 
 	_, _, err = s.client.Session().Renew(session, nil)
-	if err != nil {
-		return s.refreshSession(pair, ttl)
-	}
-	return nil
+	return err
 }
 
 // getActiveSession checks if the key already has
@@ -183,10 +188,16 @@ func (s *Consul) Put(key string, value []byte, opts *store.WriteOptions) error {
 	}
 
 	if opts != nil && opts.TTL > 0 {
-		// Create or refresh the session
-		err := s.refreshSession(p, opts.TTL)
-		if err != nil {
-			return err
+		// Create or renew a session holding a TTL. Operations on sessions
+		// are not deterministic: creating or renewing a session can fail
+		for retry := 1; retry <= RenewSessionRetryMax; retry++ {
+			err := s.renewSession(p, opts.TTL)
+			if err == nil {
+				break
+			}
+			if retry == RenewSessionRetryMax {
+				return ErrSessionRenew
+			}
 		}
 	}
 


### PR DESCRIPTION
Add a simple retry mechanism for session renewal when using `TTLs` in case the version of Consul is < `0.5.0` or more generally does not support sessions to hold a TTL.

Before, if using an unsupported version of Consul, the session renew would hang not throwing any useful error to the user.

Signed-off-by: Alexandre Beslic <abronan@docker.com>