### PR TITLE
Fix AtomicPut panic if previous KVPair is not nil and key not exists in boltdb

### DIFF
--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -257,6 +257,9 @@ func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair, opt
 			return store.ErrKeyModified
 		}
 		if previous != nil {
+			if len(val) == 0 {
+				return store.ErrKeyNotFound
+			}
 			dbIndex = binary.LittleEndian.Uint64(val[:libkvmetadatalen])
 			if dbIndex != previous.LastIndex {
 				return store.ErrKeyModified


### PR DESCRIPTION
Signed-off-by: Chun Chen <ramichen@tencent.com>

Found this bug during running unit tests of libnetwork. 