### PR TITLE
Add TTL to Consul lock using store.LockOptions

### DIFF
--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -35,7 +35,8 @@ type Consul struct {
 }
 
 type consulLock struct {
-	lock *api.Lock
+	lock    *api.Lock
+	renewCh chan struct{}
 }
 
 // Register registers consul to libkv
@@ -360,32 +361,63 @@ func (s *Consul) WatchTree(directory string, stopCh <-chan struct{}) (<-chan []*
 // NewLock returns a handle to a lock struct which can
 // be used to provide mutual exclusion on a key
 func (s *Consul) NewLock(key string, options *store.LockOptions) (store.Locker, error) {
-	consulOpts := &api.LockOptions{
+	lockOpts := &api.LockOptions{
 		Key: s.normalize(key),
 	}
 
+	lock := &consulLock{}
+
 	if options != nil {
-		consulOpts.Value = options.Value
+		// Set optional TTL on Lock
+		if options.TTL != 0 {
+			entry := &api.SessionEntry{
+				Behavior:  api.SessionBehaviorRelease, // Release the lock when the session expires
+				TTL:       (options.TTL / 2).String(), // Consul multiplies the TTL by 2x
+				LockDelay: 1 * time.Millisecond,       // Virtually disable lock delay
+			}
+
+			// Create the key session
+			session, _, err := s.client.Session().Create(entry, nil)
+			if err != nil {
+				return nil, err
+			}
+
+			// Place the session on lock
+			lockOpts.Session = session
+
+			// Renew the session ttl lock periodically
+			go s.client.Session().RenewPeriodic(entry.TTL, session, nil, options.RenewLock)
+			lock.renewCh = options.RenewLock
+		}
+
+		// Set optional value on Lock
+		if options.Value != nil {
+			lockOpts.Value = options.Value
+		}
 	}
 
-	l, err := s.client.LockOpts(consulOpts)
+	l, err := s.client.LockOpts(lockOpts)
 	if err != nil {
 		return nil, err
 	}
 
-	return &consulLock{lock: l}, nil
+	lock.lock = l
+	return lock, nil
 }
 
 // Lock attempts to acquire the lock and blocks while
 // doing so. It returns a channel that is closed if our
 // lock is lost or if an error occurs
-func (l *consulLock) Lock() (<-chan struct{}, error) {
-	return l.lock.Lock(nil)
+func (l *consulLock) Lock(stopChan chan struct{}) (<-chan struct{}, error) {
+	return l.lock.Lock(stopChan)
 }
 
 // Unlock the "key". Calling unlock while
 // not holding the lock will throw an error
 func (l *consulLock) Unlock() error {
+	if l.renewCh != nil {
+		close(l.renewCh)
+	}
 	return l.lock.Unlock()
 }
 

--- a/store/consul/consul_test.go
+++ b/store/consul/consul_test.go
@@ -44,13 +44,15 @@ func TestRegister(t *testing.T) {
 
 func TestConsulStore(t *testing.T) {
 	kv := makeConsulClient(t)
-	backup := makeConsulClient(t)
+	lockKV := makeConsulClient(t)
+	ttlKV := makeConsulClient(t)
 
 	testutils.RunTestCommon(t, kv)
 	testutils.RunTestAtomic(t, kv)
 	testutils.RunTestWatch(t, kv)
 	testutils.RunTestLock(t, kv)
-	testutils.RunTestTTL(t, kv, backup)
+	testutils.RunTestLockTTL(t, kv, lockKV)
+	testutils.RunTestTTL(t, kv, ttlKV)
 	testutils.RunCleanup(t, kv)
 }
 

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -19,12 +19,13 @@ type Etcd struct {
 }
 
 type etcdLock struct {
-	client   *etcd.Client
-	stopLock chan struct{}
-	key      string
-	value    string
-	last     *etcd.Response
-	ttl      uint64
+	client    *etcd.Client
+	stopLock  chan struct{}
+	stopRenew chan struct{}
+	key       string
+	value     string
+	last      *etcd.Response
+	ttl       uint64
 }
 
 const (
@@ -395,6 +396,7 @@ func (s *Etcd) DeleteTree(directory string) error {
 func (s *Etcd) NewLock(key string, options *store.LockOptions) (lock store.Locker, err error) {
 	var value string
 	ttl := uint64(time.Duration(defaultLockTTL).Seconds())
+	renewCh := make(chan struct{})
 
 	// Apply options on Lock
 	if options != nil {
@@ -404,14 +406,18 @@ func (s *Etcd) NewLock(key string, options *store.LockOptions) (lock store.Locke
 		if options.TTL != 0 {
 			ttl = uint64(options.TTL.Seconds())
 		}
+		if options.RenewLock != nil {
+			renewCh = options.RenewLock
+		}
 	}
 
 	// Create lock object
 	lock = &etcdLock{
-		client: s.client,
-		key:    key,
-		value:  value,
-		ttl:    ttl,
+		client:    s.client,
+		stopRenew: renewCh,
+		key:       key,
+		value:     value,
+		ttl:       ttl,
 	}
 
 	return lock, nil
@@ -420,13 +426,13 @@ func (s *Etcd) NewLock(key string, options *store.LockOptions) (lock store.Locke
 // Lock attempts to acquire the lock and blocks while
 // doing so. It returns a channel that is closed if our
 // lock is lost or if an error occurs
-func (l *etcdLock) Lock() (<-chan struct{}, error) {
+func (l *etcdLock) Lock(stopChan chan struct{}) (<-chan struct{}, error) {
 
 	key := store.Normalize(l.key)
 
-	// Lock holder channels
+	// Lock holder channel
 	lockHeld := make(chan struct{})
-	stopLocking := make(chan struct{})
+	stopLocking := l.stopRenew
 
 	var lastIndex uint64
 
@@ -454,7 +460,18 @@ func (l *etcdLock) Lock() (<-chan struct{}, error) {
 			// Seeker section
 			chW := make(chan *etcd.Response)
 			chWStop := make(chan bool)
-			l.waitLock(key, chW, chWStop)
+			free := make(chan bool)
+
+			go l.waitLock(key, chW, chWStop, free)
+
+			// Wait for the key to be available or for
+			// a signal to stop trying to lock the key
+			select {
+			case _ = <-free:
+				break
+			case _ = <-stopChan:
+				return nil, nil
+			}
 
 			// Delete or Expire event occured
 			// Retry
@@ -467,10 +484,10 @@ func (l *etcdLock) Lock() (<-chan struct{}, error) {
 // Hold the lock as long as we can
 // Updates the key ttl periodically until we receive
 // an explicit stop signal from the Unlock method
-func (l *etcdLock) holdLock(key string, lockHeld chan struct{}, stopLocking chan struct{}) {
+func (l *etcdLock) holdLock(key string, lockHeld chan struct{}, stopLocking <-chan struct{}) {
 	defer close(lockHeld)
 
-	update := time.NewTicker(defaultUpdateTime)
+	update := time.NewTicker(time.Duration((l.ttl / 3) + 1))
 	defer update.Stop()
 
 	var err error
@@ -490,11 +507,12 @@ func (l *etcdLock) holdLock(key string, lockHeld chan struct{}, stopLocking chan
 }
 
 // WaitLock simply waits for the key to be available for creation
-func (l *etcdLock) waitLock(key string, eventCh chan *etcd.Response, stopWatchCh chan bool) {
+func (l *etcdLock) waitLock(key string, eventCh chan *etcd.Response, stopWatchCh chan bool, free chan<- bool) {
 	go l.client.Watch(key, 0, false, eventCh, stopWatchCh)
+
 	for event := range eventCh {
 		if event.Action == "delete" || event.Action == "expire" {
-			return
+			free <- true
 		}
 	}
 }

--- a/store/etcd/etcd_test.go
+++ b/store/etcd/etcd_test.go
@@ -43,12 +43,14 @@ func TestRegister(t *testing.T) {
 
 func TestEtcdStore(t *testing.T) {
 	kv := makeEtcdClient(t)
-	backup := makeEtcdClient(t)
+	lockKV := makeEtcdClient(t)
+	ttlKV := makeEtcdClient(t)
 
 	testutils.RunTestCommon(t, kv)
 	testutils.RunTestAtomic(t, kv)
 	testutils.RunTestWatch(t, kv)
 	testutils.RunTestLock(t, kv)
-	testutils.RunTestTTL(t, kv, backup)
+	testutils.RunTestLockTTL(t, kv, lockKV)
+	testutils.RunTestTTL(t, kv, ttlKV)
 	testutils.RunCleanup(t, kv)
 }

--- a/store/mock/mock.go
+++ b/store/mock/mock.go
@@ -96,8 +96,8 @@ type Lock struct {
 }
 
 // Lock mock
-func (l *Lock) Lock() (<-chan struct{}, error) {
-	args := l.Mock.Called()
+func (l *Lock) Lock(stopCh chan struct{}) (<-chan struct{}, error) {
+	args := l.Mock.Called(stopCh)
 	return args.Get(0).(<-chan struct{}), args.Error(1)
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -113,13 +113,14 @@ type WriteOptions struct {
 
 // LockOptions contains optional request parameters
 type LockOptions struct {
-	Value []byte        // Optional, value to associate with the lock
-	TTL   time.Duration // Optional, expiration ttl associated with the lock
+	Value     []byte        // Optional, value to associate with the lock
+	TTL       time.Duration // Optional, expiration ttl associated with the lock
+	RenewLock chan struct{} // Optional, chan used to control and stop the session ttl renewal for the lock
 }
 
 // Locker provides locking mechanism on top of the store.
 // Similar to `sync.Lock` except it may return errors.
 type Locker interface {
-	Lock() (<-chan struct{}, error)
+	Lock(stopChan chan struct{}) (<-chan struct{}, error)
 	Unlock() error
 }

--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -371,7 +371,7 @@ func (s *Zookeeper) NewLock(key string, options *store.LockOptions) (lock store.
 // Lock attempts to acquire the lock and blocks while
 // doing so. It returns a channel that is closed if our
 // lock is lost or if an error occurs
-func (l *zookeeperLock) Lock() (<-chan struct{}, error) {
+func (l *zookeeperLock) Lock(stopChan chan struct{}) (<-chan struct{}, error) {
 	err := l.lock.Lock()
 
 	if err == nil {

--- a/store/zookeeper/zookeeper_test.go
+++ b/store/zookeeper/zookeeper_test.go
@@ -43,12 +43,12 @@ func TestRegister(t *testing.T) {
 
 func TestZkStore(t *testing.T) {
 	kv := makeZkClient(t)
-	backup := makeZkClient(t)
+	ttlKV := makeZkClient(t)
 
 	testutils.RunTestCommon(t, kv)
 	testutils.RunTestAtomic(t, kv)
 	testutils.RunTestWatch(t, kv)
 	testutils.RunTestLock(t, kv)
-	testutils.RunTestTTL(t, kv, backup)
+	testutils.RunTestTTL(t, kv, ttlKV)
 	testutils.RunCleanup(t, kv)
 }

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -38,6 +38,12 @@ func RunTestLock(t *testing.T, kv store.Store) {
 	testLockUnlock(t, kv)
 }
 
+// RunTestLockTTL tests the KV pair Lock with TTL APIs supported
+// by the K/V backends.
+func RunTestLockTTL(t *testing.T, kv store.Store, backup store.Store) {
+	testLockTTL(t, kv, backup)
+}
+
 // RunTestTTL tests the TTL funtionality of the K/V backend.
 func RunTestTTL(t *testing.T, kv store.Store, backup store.Store) {
 	testPutTTL(t, kv, backup)
@@ -307,7 +313,7 @@ func testLockUnlock(t *testing.T, kv store.Store) {
 	assert.NotNil(t, lock)
 
 	// Lock should successfully succeed or block
-	lockChan, err := lock.Lock()
+	lockChan, err := lock.Lock(nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, lockChan)
 
@@ -325,7 +331,7 @@ func testLockUnlock(t *testing.T, kv store.Store) {
 	assert.NoError(t, err)
 
 	// Lock should succeed again
-	lockChan, err = lock.Lock()
+	lockChan, err = lock.Lock(nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, lockChan)
 
@@ -337,6 +343,110 @@ func testLockUnlock(t *testing.T, kv store.Store) {
 	}
 	assert.Equal(t, pair.Value, value)
 	assert.NotEqual(t, pair.LastIndex, 0)
+
+	err = lock.Unlock()
+	assert.NoError(t, err)
+}
+
+func testLockTTL(t *testing.T, kv store.Store, otherConn store.Store) {
+	key := "testLockTTL"
+	value := []byte("bar")
+
+	renewCh := make(chan struct{})
+
+	// We should be able to create a new lock on key
+	lock, err := otherConn.NewLock(key, &store.LockOptions{
+		Value:     value,
+		TTL:       2 * time.Second,
+		RenewLock: renewCh,
+	})
+	assert.NoError(t, err)
+	assert.NotNil(t, lock)
+
+	// Lock should successfully succeed
+	lockChan, err := lock.Lock(nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, lockChan)
+
+	// Get should work
+	pair, err := otherConn.Get(key)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair) {
+		assert.NotNil(t, pair.Value)
+	}
+	assert.Equal(t, pair.Value, value)
+	assert.NotEqual(t, pair.LastIndex, 0)
+
+	time.Sleep(3 * time.Second)
+
+	done := make(chan struct{})
+	stop := make(chan struct{})
+
+	value = []byte("foobar")
+
+	// Create a new lock with another connection
+	lock, err = kv.NewLock(
+		key,
+		&store.LockOptions{
+			Value: value,
+			TTL:   3 * time.Second,
+		},
+	)
+	assert.NoError(t, err)
+	assert.NotNil(t, lock)
+
+	// Lock should block, the session on the lock
+	// is still active and renewed periodically
+	go func(<-chan struct{}) {
+		_, _ = lock.Lock(stop)
+		done <- struct{}{}
+	}(done)
+
+	select {
+	case _ = <-done:
+		t.Fatal("Lock succeeded on a key that is supposed to be locked by another client")
+	case <-time.After(4 * time.Second):
+		// Stop requesting the lock as we are blocked as expected
+		stop <- struct{}{}
+		break
+	}
+
+	// Close the connection
+	otherConn.Close()
+
+	// Force stop the session renewal for the lock
+	close(renewCh)
+
+	// Let the session on the lock expire
+	time.Sleep(3 * time.Second)
+	locked := make(chan struct{})
+
+	// Lock should now succeed for the other client
+	go func(<-chan struct{}) {
+		lockChan, err = lock.Lock(nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, lockChan)
+		locked <- struct{}{}
+	}(locked)
+
+	select {
+	case _ = <-locked:
+		break
+	case <-time.After(4 * time.Second):
+		t.Fatal("Unable to take the lock, timed out")
+	}
+
+	// Get should work with the new value
+	pair, err = kv.Get(key)
+	assert.NoError(t, err)
+	if assert.NotNil(t, pair) {
+		assert.NotNil(t, pair.Value)
+	}
+	assert.Equal(t, pair.Value, value)
+	assert.NotEqual(t, pair.LastIndex, 0)
+
+	err = lock.Unlock()
+	assert.NoError(t, err)
 }
 
 func testPutTTL(t *testing.T, kv store.Store, otherConn store.Store) {
@@ -482,6 +592,7 @@ func RunCleanup(t *testing.T, kv store.Store) {
 		"testAtomicPutCreate",
 		"testAtomicDelete",
 		"testLockUnlock",
+		"testLockTTL",
 		"testPutTTL",
 		"testList",
 		"testDeleteTree",


### PR DESCRIPTION
Related to docker/swarm#930 and docker/swarm#1227

Add TTL on `Lock` for Consul and add tests for `etcd`, `consul` and `zookeeper`.

Also includes a `stopChan` for Consul and etcd in order to perform the test on the Lock `TTL`.

Signed-off-by: Alexandre Beslic <abronan@docker.com>