### PR TITLE
Drops 'to end users' from documentation license grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ Want to hack on libkv? [Docker's contributions guidelines](https://github.com/do
 
 ##Copyright and license
 
-Copyright © 2014-2015 Docker, Inc. All rights reserved, except as follows. Code is released under the Apache 2.0 license. Documentation is licensed to end users under the Creative Commons Attribution 4.0 International License under the terms and conditions set forth in the file "LICENSE.docs". You may obtain a duplicate copy of the same license, titled CC-BY-SA-4.0, at http://creativecommons.org/licenses/by/4.0/.
+Copyright © 2014-2015 Docker, Inc. All rights reserved, except as follows. Code is released under the Apache 2.0 license. The README.md file, and files in the "docs" folder are licensed under the Creative Commons Attribution 4.0 International License under the terms and conditions set forth in the file "LICENSE.docs". You may obtain a duplicate copy of the same license, titled CC-BY-SA-4.0, at http://creativecommons.org/licenses/by/4.0/.


### PR DESCRIPTION
Fixes #50 

Drops the **"to end users"** from documentation license grant as this seems superfluous and confusing (and not following the Creative Commons official guidelines).

/cc @onlyjob @thaJeztah @moxiegirl does that sound good to you? Thanks.

Signed-off-by: Alexandre Beslic <abronan@docker.com>