### PR TITLE
Fix typo in comment

### DIFF
--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -88,7 +88,7 @@ func (s *Consul) setTLS(tls *tls.Config) {
 	s.config.Scheme = "https"
 }
 
-// SetTimeout sets the timout for connecting to Consul
+// SetTimeout sets the timeout for connecting to Consul
 func (s *Consul) setTimeout(time time.Duration) {
 	s.config.WaitTime = time
 }


### PR DESCRIPTION
Hi, I think there is a misspelling in your comment.
How about this?
"timout" to "timeout"