### PR TITLE
Fix incorrect Etcd lock ticker initialization

### DIFF
--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -495,7 +495,7 @@ func (l *etcdLock) Lock(stopChan chan struct{}) (<-chan struct{}, error) {
 func (l *etcdLock) holdLock(key string, lockHeld chan struct{}, stopLocking <-chan struct{}) {
 	defer close(lockHeld)
 
-	update := time.NewTicker(time.Duration((l.ttl / 3) + 1))
+	update := time.NewTicker(time.Duration(l.ttl) * time.Second / 3)
 	defer update.Stop()
 
 	var err error


### PR DESCRIPTION
Etcd TTLs are in seconds, without this fix the
ticker goes off uncontrollably every millisecond,
flooding etcd with put requests
Signed-off-by: Mariusz Borsa <mborsa@polyverse.io>