### PR TITLE
Return store.ErrKeyExists on AtomicPut

### DIFF
--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -381,7 +381,7 @@ func (b *BoltDB) AtomicPut(key string, value []byte, previous *store.KVPair, opt
 		// doesn't exist in the DB.
 		val = bucket.Get([]byte(key))
 		if previous == nil && len(val) != 0 {
-			return store.ErrKeyModified
+			return store.ErrKeyExists
 		}
 		if previous != nil {
 			if len(val) == 0 {

--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -445,9 +445,14 @@ func (s *Consul) AtomicPut(key string, value []byte, previous *store.KVPair, opt
 		p.ModifyIndex = previous.LastIndex
 	}
 
-	if work, _, err := s.client.KV().CAS(p, nil); err != nil {
+	ok, _, err := s.client.KV().CAS(p, nil)
+	if err != nil {
 		return false, nil, err
-	} else if !work {
+	}
+	if !ok {
+		if previous == nil {
+			return false, nil, store.ErrKeyExists
+		}
 		return false, nil, store.ErrKeyModified
 	}
 

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -335,6 +335,10 @@ func (s *Etcd) AtomicPut(key string, value []byte, previous *store.KVPair, opts 
 			if etcdError.Code == etcd.ErrorCodeTestFailed {
 				return false, nil, store.ErrKeyModified
 			}
+			// Node exists error (when PrevNoExist)
+			if etcdError.Code == etcd.ErrorCodeNodeExist {
+				return false, nil, store.ErrKeyExists
+			}
 		}
 		return false, nil, err
 	}

--- a/store/store.go
+++ b/store/store.go
@@ -35,6 +35,8 @@ var (
 	ErrKeyNotFound = errors.New("Key not found in store")
 	// ErrPreviousNotSpecified is thrown when the previous value is not specified for an atomic operation
 	ErrPreviousNotSpecified = errors.New("Previous K/V pair should be provided for the Atomic operation")
+	// ErrKeyExists is thrown when the previous value exists in the case of an AtomicPut
+	ErrKeyExists = errors.New("Previous K/V pair exists, cannnot complete Atomic operation")
 )
 
 // Config contains the options for a storage client

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -266,7 +266,7 @@ func testAtomicPutCreate(t *testing.T, kv store.Store) {
 
 	// Attempting to create again should fail.
 	success, _, err = kv.AtomicPut(key, value, nil, nil)
-	assert.Error(t, err)
+	assert.Error(t, store.ErrKeyExists)
 	assert.False(t, success)
 
 	// This CAS should succeed, since it has the value from Get()


### PR DESCRIPTION
When using AtomicPut with 'previous' set at nil, it interprets
that the Key should be created with the AtomicPut. Instead of
returning a generic error, we return store.ErrKeyExists if the
key exists in the store during the operation.

Signed-off-by: Alexandre Beslic <abronan@docker.com>