### PR TITLE
Carry #82: Fix zookeeper atomic put suffix key

### DIFF
--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -310,7 +310,7 @@ func (s *Zookeeper) AtomicPut(key string, value []byte, previous *store.KVPair, 
 			// Zookeeper will complain if the directory doesn't exist.
 			if err == zk.ErrNoNode {
 				// Create the directory
-				parts := store.SplitKey(key)
+				parts := store.SplitKey(strings.TrimSuffix(key, "/"))
 				parts = parts[:len(parts)-1]
 				if err = s.createFullPath(parts, false); err != nil {
 					// Failed to create the directory.

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -22,7 +22,7 @@ func RunTestCommon(t *testing.T, kv store.Store) {
 func RunTestAtomic(t *testing.T, kv store.Store) {
 	testAtomicPut(t, kv)
 	testAtomicPutCreate(t, kv)
-	testAtomicPutWithSlashSuffuxKey(t, kv)
+	testAtomicPutWithSlashSuffixKey(t, kv)
 	testAtomicDelete(t, kv)
 }
 
@@ -275,8 +275,8 @@ func testAtomicPutCreate(t *testing.T, kv store.Store) {
 	assert.True(t, success)
 }
 
-func testAtomicPutWithSlashSuffuxKey(t *testing.T, kv store.Store) {
-	k1 := "testAtomicPutWithSlashSuffuxKey/key/"
+func testAtomicPutWithSlashSuffixKey(t *testing.T, kv store.Store) {
+	k1 := "testAtomicPutWithSlashSuffixKey/key/"
 	success, _, err := kv.AtomicPut(k1, []byte{}, nil, nil)
 	assert.Nil(t, err)
 	assert.True(t, success)
@@ -596,6 +596,7 @@ func testDeleteTree(t *testing.T, kv store.Store) {
 // RunCleanup cleans up keys introduced by the tests
 func RunCleanup(t *testing.T, kv store.Store) {
 	for _, key := range []string{
+		"testAtomicPutWithSlashSuffixKey",
 		"testPutGetDeleteExists",
 		"testWatch",
 		"testWatchTree",

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -22,6 +22,7 @@ func RunTestCommon(t *testing.T, kv store.Store) {
 func RunTestAtomic(t *testing.T, kv store.Store) {
 	testAtomicPut(t, kv)
 	testAtomicPutCreate(t, kv)
+	testAtomicPutWithSlashSuffuxKey(t, kv)
 	testAtomicDelete(t, kv)
 }
 
@@ -271,6 +272,13 @@ func testAtomicPutCreate(t *testing.T, kv store.Store) {
 	// This CAS should succeed, since it has the value from Get()
 	success, _, err = kv.AtomicPut(key, []byte("PUTCREATE"), pair, nil)
 	assert.NoError(t, err)
+	assert.True(t, success)
+}
+
+func testAtomicPutWithSlashSuffuxKey(t *testing.T, kv store.Store) {
+	k1 := "testAtomicPutWithSlashSuffuxKey/key/"
+	success, _, err := kv.AtomicPut(k1, []byte{}, nil, nil)
+	assert.Nil(t, err)
 	assert.True(t, success)
 }
 


### PR DESCRIPTION
Carrying to make sure we get this on time for the freeze.

replaces #82 

ping @mavenugo @chenchun 