### PR TITLE
boltDB AtomicDelete fails for non-existent key

### DIFF
--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -330,6 +330,9 @@ func (b *BoltDB) AtomicDelete(key string, previous *store.KVPair) (bool, error) 
 		}
 
 		val = bucket.Get([]byte(key))
+		if val == nil {
+			return store.ErrKeyNotFound
+		}
 		dbIndex := binary.LittleEndian.Uint64(val[:libkvmetadatalen])
 		if dbIndex != previous.LastIndex {
 			return store.ErrKeyModified

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -312,6 +312,11 @@ func testAtomicDelete(t *testing.T, kv store.Store) {
 	success, err = kv.AtomicDelete(key, pair)
 	assert.NoError(t, err)
 	assert.True(t, success)
+
+	// Delete a non-existent key; should fail
+	success, err = kv.AtomicDelete(key, pair)
+	assert.Error(t, err)
+	assert.False(t, success)
 }
 
 func testLockUnlock(t *testing.T, kv store.Store) {


### PR DESCRIPTION
Signed-off-by: Santhosh Manohar <santhosh@docker.com>