### PR TITLE
Align ErrKeyNotFound error on AtomicDelete for all backends

### DIFF
--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -467,6 +467,13 @@ func (s *Consul) AtomicDelete(key string, previous *store.KVPair) (bool, error) 
 	}
 
 	p := &api.KVPair{Key: s.normalize(key), ModifyIndex: previous.LastIndex}
+
+	// Extra Get operation to check on the key
+	_, err := s.Get(key)
+	if err != nil && err == store.ErrKeyNotFound {
+		return false, err
+	}
+
 	if work, _, err := s.client.KV().DeleteCAS(p, nil); err != nil {
 		return false, err
 	} else if !work {

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -368,6 +368,10 @@ func (s *Etcd) AtomicDelete(key string, previous *store.KVPair) (bool, error) {
 	_, err := s.client.Delete(context.Background(), s.normalize(key), delOpts)
 	if err != nil {
 		if etcdError, ok := err.(etcd.Error); ok {
+			// Key Not Found
+			if etcdError.Code == etcd.ErrorCodeKeyNotFound {
+				return false, store.ErrKeyNotFound
+			}
 			// Compare failed
 			if etcdError.Code == etcd.ErrorCodeTestFailed {
 				return false, store.ErrKeyModified

--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -347,9 +347,15 @@ func (s *Zookeeper) AtomicDelete(key string, previous *store.KVPair) (bool, erro
 
 	err := s.client.Delete(s.normalize(key), int32(previous.LastIndex))
 	if err != nil {
+		// Key not found
+		if err == zk.ErrNoNode {
+			return false, store.ErrKeyNotFound
+		}
+		// Compare failed
 		if err == zk.ErrBadVersion {
 			return false, store.ErrKeyModified
 		}
+		// General store error
 		return false, err
 	}
 	return true, nil

--- a/testutils/utils.go
+++ b/testutils/utils.go
@@ -315,7 +315,7 @@ func testAtomicDelete(t *testing.T, kv store.Store) {
 
 	// Delete a non-existent key; should fail
 	success, err = kv.AtomicDelete(key, pair)
-	assert.Error(t, err)
+	assert.Error(t, store.ErrKeyNotFound)
 	assert.False(t, success)
 }
 


### PR DESCRIPTION
Align on #86 to throw `ErrKeyNotFound` on `AtomicDelete` for every backend

/cc @sanimej @mavenugo 

Signed-off-by: Alexandre Beslic <abronan@docker.com>