### PR TITLE
Improve Consul lock

### DIFF
--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -396,6 +396,11 @@ func (s *Consul) NewLock(key string, options *store.LockOptions) (store.Locker, 
 			// Place the session on lock
 			lockOpts.Session = session
 
+			// Monitor retries in case of store restart
+			// or network high latency/erratic behavior
+			lockOpts.MonitorRetries = 3
+			lockOpts.MonitorRetryTime = 3 * time.Second
+
 			// Renew the session ttl lock periodically
 			go s.client.Session().RenewPeriodic(entry.TTL, session, nil, options.RenewLock)
 			lock.renewCh = options.RenewLock

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -41,7 +41,7 @@ type etcdLock struct {
 
 const (
 	periodicSync      = 5 * time.Minute
-	defaultLockTTL    = 20 * time.Second
+	defaultLockTTL    = 15 * time.Second
 	defaultUpdateTime = 5 * time.Second
 )
 


### PR DESCRIPTION
Improves Consul Lock:
- Cleanup the Session on failure in case of custom Session usage
- Use Monitor retries in case of network failures
- Align etcd default lock TTL to match the one of Consul
