### PR TITLE
Consul expects "magic" flag to support locking a kvpair

### DIFF
--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -186,6 +186,7 @@ func (s *Consul) Put(key string, value []byte, opts *store.WriteOptions) error {
 	p := &api.KVPair{
 		Key:   key,
 		Value: value,
+		Flags: api.LockFlagValue,
 	}
 
 	if opts != nil && opts.TTL > 0 {
@@ -436,7 +437,7 @@ func (l *consulLock) Unlock() error {
 // modified in the meantime, throws an error if this is the case
 func (s *Consul) AtomicPut(key string, value []byte, previous *store.KVPair, options *store.WriteOptions) (bool, *store.KVPair, error) {
 
-	p := &api.KVPair{Key: s.normalize(key), Value: value}
+	p := &api.KVPair{Key: s.normalize(key), Value: value, Flags: api.LockFlagValue}
 
 	if previous == nil {
 		// Consul interprets ModifyIndex = 0 as new key.
@@ -471,7 +472,7 @@ func (s *Consul) AtomicDelete(key string, previous *store.KVPair) (bool, error) 
 		return false, store.ErrPreviousNotSpecified
 	}
 
-	p := &api.KVPair{Key: s.normalize(key), ModifyIndex: previous.LastIndex}
+	p := &api.KVPair{Key: s.normalize(key), ModifyIndex: previous.LastIndex, Flags: api.LockFlagValue}
 
 	// Extra Get operation to check on the key
 	_, err := s.Get(key)


### PR DESCRIPTION
@abronan while experimenting with libkv's lock functionality with consul backend, I observed `ErrLockConflict` error from https://github.com/hashicorp/consul/blob/06926f3b3556716c985c8df7a9ff77fa5096c719/api/lock.go#L195

It seems consul is expecting a magic value of `LockFlagValue` in the KVPair's Flag in order to allow locking the key.

This PR is just to discuss the issue and a quick hack that I added in libkv.

AFAIK swarm uses lock functionality for leader election. But it doesnt seem to be impacted by this in a consul backend. Can you share any info you might have on this ?

Signed-off-by: Madhu Venugopal <madhu@docker.com>