### PR TITLE
Fix typo in error text

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -36,7 +36,7 @@ var (
 	// ErrPreviousNotSpecified is thrown when the previous value is not specified for an atomic operation
 	ErrPreviousNotSpecified = errors.New("Previous K/V pair should be provided for the Atomic operation")
 	// ErrKeyExists is thrown when the previous value exists in the case of an AtomicPut
-	ErrKeyExists = errors.New("Previous K/V pair exists, cannnot complete Atomic operation")
+	ErrKeyExists = errors.New("Previous K/V pair exists, cannot complete Atomic operation")
 )
 
 // Config contains the options for a storage client


### PR DESCRIPTION
The typo was found and fixed by codespell.

Signed-off-by: Stefan Weil <sw@weilnetz.de>