### PR TITLE
Add support for etcd authentication

### DIFF
--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -75,6 +75,9 @@ func New(addrs []string, options *store.Config) (store.Store, error) {
 		if options.ConnectionTimeout != 0 {
 			setTimeout(cfg, options.ConnectionTimeout)
 		}
+		if options.Username != "" {
+			setCredentials(cfg, options.Username, options.Password)
+		}
 	}
 
 	c, err := etcd.New(*cfg)
@@ -117,6 +120,12 @@ func setTLS(cfg *etcd.Config, tls *tls.Config, addrs []string) {
 // setTimeout sets the timeout used for connecting to the store
 func setTimeout(cfg *etcd.Config, time time.Duration) {
 	cfg.HeaderTimeoutPerRequest = time
+}
+
+// setCredentials sets the username/password credentials for connecting to Etcd
+func setCredentials(cfg *etcd.Config, username, password string) {
+	cfg.Username = username
+	cfg.Password = password
 }
 
 // Normalize the key for usage in Etcd

--- a/store/etcd/etcd_test.go
+++ b/store/etcd/etcd_test.go
@@ -19,6 +19,8 @@ func makeEtcdClient(t *testing.T) store.Store {
 		[]string{client},
 		&store.Config{
 			ConnectionTimeout: 3 * time.Second,
+			Username:          "test",
+			Password:          "very-secure",
 		},
 	)
 

--- a/store/store.go
+++ b/store/store.go
@@ -46,6 +46,8 @@ type Config struct {
 	ConnectionTimeout time.Duration
 	Bucket            string
 	PersistConnection bool
+	Username          string
+	Password          string
 }
 
 // ClientTLSConfig contains data for a Client TLS configuration in the form


### PR DESCRIPTION
fixes #119 

This is the most simple solution to add support for etcd authentication. As explained in #119, this feature was added in etcd version 2.1. @abronan was concerned about compatibility of this feature with future versions of the etcd API. I thought about this and came up with the plan to 

* suggest this minimalistic change 
* discuss here whether the credentials one can set on the `store.Config` should better be more abstract.

### Variations I could imagine are:

In both cases, the backends that support authentication would have to check whether the configured credential type is supported in their constructor.

### Flexible support for all kinds of credentials

By introducing a `Credentials` interface, one could make different types of credentials pluggable.

```go
// store/store.go
type Config struct {
	...
	Credentials Credentials
}
type Credentials interface{}

// store/etcd/etcd.go
type EtcdV2Credentials struct {
	Username string
	Password string
}

// main.go
store := libkv.NewStore(store.ETCD, machines, &store.Config{
	Credentials: &etcd.EtcdV2Credentials{
		Username: "my-user",
		Password: "my-password",
	},
})
```

### Flexible without having to expose the etcd package

```go
// store/store.go
type Config struct {
	...
	Credentials Credentials
}
type Credentials interface{}

type UsernamePasswordCredentials struct {
	Username string
	Password string
}

// main.go
store := libkv.NewStore(store.ETCD, machines, &store.Config{
	Credentials: &store.UsernamePasswordCredentials{
		Username: "my-user",
		Password: "my-password",
	},
})
```