### PR TITLE
Use fork of go-zookeeper

### DIFF
--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
-	zk "github.com/samuel/go-zookeeper/zk"
+	zk "github.com/talbright/go-zookeeper/zk"
 )
 
 const (


### PR DESCRIPTION
This fork of zk has a number of fixes and backwards compatible enhancements.
One of those enhancements allows for watches to be canceled, something that
can be added to Watch and WatchTree to make things cleaner.

Signed-off-by: Trent Albright <trent.albright@gmail.com>