### PR TITLE
Increase transientTimeout of boltdb to 2m

### DIFF
--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -45,7 +45,7 @@ type BoltDB struct {
 
 const (
 	libkvmetadatalen = 8
-	transientTimeout = time.Duration(10) * time.Second
+	transientTimeout = time.Duration(120) * time.Second
 )
 
 // Register registers boltdb to libkv


### PR DESCRIPTION
During docker stress test, there are a lot of
timeout errors on update libnetwork object to store.
`ERRO[0137] docker: Error response from daemon: failed
to update store for object type *libnetwork.endpoint: timeout.
  error=exit status 125`

I think we should increase the timeout to 2m because 2m is also the
timeout of container starting timeout of docker.

Signed-off-by: Lei Jitang <leijitang@huawei.com>