### PR TITLE
Allow client to set boltdb timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.5.3
+  - 1.7.1
 
 # let us have speedy Docker-based Travis workers
 sudo: false

--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -59,6 +59,7 @@ func New(endpoints []string, options *store.Config) (store.Store, error) {
 		db          *bolt.DB
 		err         error
 		boltOptions *bolt.Options
+		timeout     = transientTimeout
 	)
 
 	if len(endpoints) > 1 {
@@ -82,11 +83,15 @@ func New(endpoints []string, options *store.Config) (store.Store, error) {
 		}
 	}
 
+	if options.ConnectionTimeout != 0 {
+		timeout = options.ConnectionTimeout
+	}
+
 	b := &BoltDB{
 		client:            db,
 		path:              endpoints[0],
 		boltBucket:        []byte(options.Bucket),
-		timeout:           transientTimeout,
+		timeout:           timeout,
 		PersistConnection: options.PersistConnection,
 	}
 


### PR DESCRIPTION
- also in case of no persistent connection
- Also fixing CI by bumping go version in `.travis.yml`

Related to https://github.com/docker/docker/issues/26251
Related to https://github.com/docker/libnetwork/issues/1374
Supersedes #135 

Signed-off-by: Alessandro Boch aboch@docker.com
