### PR TITLE
Travis: switch to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
 script:
   - ./consul agent -server -bootstrap -advertise=127.0.0.1 -data-dir /tmp/consul -config-file=./config.json 1>/dev/null &
   - ./etcd/etcd --listen-client-urls 'http://0.0.0.0:4001' --advertise-client-urls 'http://127.0.0.1:4001' >/dev/null 2>&1 &
-  - ./zk/bin/zkServer.sh start ./zk/conf/zoo.cfg 1> /dev/null
+  - ./script/travis_start_zk.sh
   - script/validate-gofmt
   - go vet ./...
   - fgt golint ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,5 @@ script:
   - go test -v -race ./...
   - script/coverage
   - goveralls -service=travis-ci -coverprofile=goverage.report
+
+dist: trusty

--- a/script/travis_start_zk.sh
+++ b/script/travis_start_zk.sh
@@ -1,0 +1,11 @@
+#! /bin/bash
+
+while true; do
+  ./zk/bin/zkServer.sh start ./zk/conf/zoo.cfg
+  sleep 3
+  if echo stat |nc localhost 2181 |grep -q Mode; then
+    break
+  fi
+  echo zk did not start properly, retrying...
+  ./zk/bin/zkServer.sh stop
+done


### PR DESCRIPTION
Upgrades travis base image to trusty. Adds a wrapper script to start zookeeper which gets stuck during initialization otherwise for unknown reasons.