### PR TITLE
specify the default http.transport

### DIFF
--- a/store/consul/consul.go
+++ b/store/consul/consul.go
@@ -73,6 +73,7 @@ func New(endpoints []string, options *store.Config) (store.Store, error) {
 	config := api.DefaultConfig()
 	s.config = config
 	config.HttpClient = http.DefaultClient
+	config.HttpClient.Transport = http.DefaultTransport
 	config.Address = endpoints[0]
 	config.Scheme = "http"
 


### PR DESCRIPTION
Signed-off-by: lwh <lwhile521@gmail.com>

Although updating the consul code can avoid this problem, I think that it's necessary to specify the default transport when the code have used the ```http.DefaultClient``` 
