### PR TITLE
Add a test for Lock Waits

### DIFF
--- a/store/consul/consul_test.go
+++ b/store/consul/consul_test.go
@@ -47,13 +47,15 @@ func TestConsulStore(t *testing.T) {
 	lockKV := makeConsulClient(t)
 	ttlKV := makeConsulClient(t)
 
+	defer testutils.RunCleanup(t, kv)
+
 	testutils.RunTestCommon(t, kv)
 	testutils.RunTestAtomic(t, kv)
 	testutils.RunTestWatch(t, kv)
 	testutils.RunTestLock(t, kv)
 	testutils.RunTestLockTTL(t, kv, lockKV)
+	testutils.RunTestLockWait(t, kv, lockKV)
 	testutils.RunTestTTL(t, kv, ttlKV)
-	testutils.RunCleanup(t, kv)
 }
 
 func TestGetActiveSession(t *testing.T) {

--- a/store/etcd/etcd_test.go
+++ b/store/etcd/etcd_test.go
@@ -48,11 +48,13 @@ func TestEtcdStore(t *testing.T) {
 	lockKV := makeEtcdClient(t)
 	ttlKV := makeEtcdClient(t)
 
+	defer testutils.RunCleanup(t, kv)
+
 	testutils.RunTestCommon(t, kv)
 	testutils.RunTestAtomic(t, kv)
 	testutils.RunTestWatch(t, kv)
 	testutils.RunTestLock(t, kv)
 	testutils.RunTestLockTTL(t, kv, lockKV)
+	testutils.RunTestLockWait(t, kv, lockKV)
 	testutils.RunTestTTL(t, kv, ttlKV)
-	testutils.RunCleanup(t, kv)
 }

--- a/store/zookeeper/zookeeper_test.go
+++ b/store/zookeeper/zookeeper_test.go
@@ -45,10 +45,11 @@ func TestZkStore(t *testing.T) {
 	kv := makeZkClient(t)
 	ttlKV := makeZkClient(t)
 
+	defer testutils.RunCleanup(t, kv)
+
 	testutils.RunTestCommon(t, kv)
 	testutils.RunTestAtomic(t, kv)
 	testutils.RunTestWatch(t, kv)
 	testutils.RunTestLock(t, kv)
 	testutils.RunTestTTL(t, kv, ttlKV)
-	testutils.RunCleanup(t, kv)
 }


### PR DESCRIPTION
Added a test case for consul and etcd which asserts that clients
correctly block if the lock key is already held by another client.
It also tests that the waiting client unblocks once the lock is
released.