### PR TITLE
Fix AutoSync when a etcd cluster is unhealthy

### DIFF
--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -105,8 +105,12 @@ func New(addrs []string, options *store.Config) (store.Store, error) {
 	// Periodic Cluster Sync
 	go func() {
 		for {
+			// AutoSync should never be broken.
+			// if so when one etcd cluster node change advise ip then docker client will never known.
 			if err := c.AutoSync(context.Background(), periodicSync); err != nil {
-				return
+				log.Printf("Failed to AutoSync from etcd,Because of %s\n", err.Error())
+				time.Sleep(periodicSyncDelay)
+				continue
 			}
 		}
 	}()


### PR DESCRIPTION
When a etcd cluster is unhealthy, the AutoSync will be broken. if etcd cluster node change it's advise ip then docker client will never known even we use domain name in docker opts.