### PR TITLE
Fix etcd AutoSync Failed when the cluster is unhealthy

### DIFF
--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -105,8 +105,12 @@ func New(addrs []string, options *store.Config) (store.Store, error) {
 	// Periodic Cluster Sync
 	go func() {
 		for {
+			// AutoSync should never be broken.
+			// if so when one etcd cluster node change advise ip then docker client will never known.
 			if err := c.AutoSync(context.Background(), periodicSync); err != nil {
-				return
+				log.Printf("Failed to AutoSync from etcd,Because of %s\n", err.Error())
+				time.Sleep(periodicSyncDelay)
+				continue
 			}
 		}
 	}()

--- a/store/etcd/etcd.go
+++ b/store/etcd/etcd.go
@@ -106,7 +106,7 @@ func New(addrs []string, options *store.Config) (store.Store, error) {
 	go func() {
 		for {
 			// AutoSync should never be broken.
-			// if so when one etcd cluster node change advise ip then docker client will never known.
+			// if so when one etcd cluster node change endpoint ip address then docker client will never known.
 			if err := c.AutoSync(context.Background(), periodicSync); err != nil {
 				log.Printf("Failed to AutoSync from etcd,Because of %s\n", err.Error())
 				time.Sleep(periodicSyncDelay)


### PR DESCRIPTION
AutoSync should never be broken,if so when one etcd cluster node change endpoint ip address then docker client will never known.