### PR TITLE
configurable zookeeper logging

### DIFF
--- a/store/store.go
+++ b/store/store.go
@@ -48,6 +48,7 @@ type Config struct {
 	PersistConnection bool
 	Username          string
 	Password          string
+	DisableLogging    bool
 }
 
 // ClientTLSConfig contains data for a Client TLS configuration in the form

--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -40,16 +40,21 @@ func Register() {
 func New(endpoints []string, options *store.Config) (store.Store, error) {
 	s := &Zookeeper{}
 	s.timeout = defaultTimeout
+	logging := true
 
 	// Set options
 	if options != nil {
 		if options.ConnectionTimeout != 0 {
 			s.setTimeout(options.ConnectionTimeout)
 		}
+
+		if options.DisableLogging {
+			logging = false
+		}
 	}
 
 	// Connect to Zookeeper
-	conn, _, err := zk.Connect(endpoints, s.timeout)
+	conn, _, err := zk.Connect(endpoints, s.timeout, zk.WithLogInfo(logging))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes #195. Adds an optional `Config.DisableLogging` bool param to the `store` package. If this param is left unspecified, the existing behavior is unchanged. Explicitly declaring the field to true will suppress the underlying `go-zookeeper` logging (see issue).