### PR TITLE
Switch boltdb to coreos/bbolt

### DIFF
--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -10,7 +10,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/boltdb/bolt"
+	"github.com/coreos/bbolt"
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
 )


### PR DESCRIPTION
The github.com/boltdb/bolt project was archived, and will no longer be actively maintained (https://github.com/boltdb/bolt/commit/fa5367d20c994db73282594be0146ab221657943)

The original author refers to coreos/bbolt as the active fork.
