### PR TITLE
boltdb/bolt is not maintained. Use bbolt instead.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.7.1
+  - 1.8.7
 
 # let us have speedy Docker-based Travis workers
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 before_script:
   - script/travis_consul.sh 0.6.3
   - script/travis_etcd.sh 3.0.0
-  - script/travis_zk.sh 3.5.1-alpha
+  - script/travis_zk.sh 3.5.4-beta
 
 script:
   - ./consul agent -server -bootstrap -advertise=127.0.0.1 -data-dir /tmp/consul -config-file=./config.json 1>/dev/null &

--- a/script/travis_zk.sh
+++ b/script/travis_zk.sh
@@ -3,7 +3,7 @@
 if [  $# -gt 0 ] ; then
     ZK_VERSION="$1"
 else
-    ZK_VERSION="3.4.7"
+    ZK_VERSION="3.5.4-beta"
 fi
 
 wget "http://apache.cs.utah.edu/zookeeper/zookeeper-${ZK_VERSION}/zookeeper-${ZK_VERSION}.tar.gz"

--- a/store/boltdb/boltdb.go
+++ b/store/boltdb/boltdb.go
@@ -10,9 +10,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/boltdb/bolt"
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
+	bolt "go.etcd.io/bbolt"
 )
 
 var (


### PR DESCRIPTION
Signed-off-by: John Howard <jhoward@microsoft.com>

Part fix for https://github.com/docker/libnetwork/issues/1950

gitHub.com/boltdb/bolt is no longer being maintained. From https://github.com/boltdb/bolt:

> Unfortunately I no longer have the time or energy to continue this work. Bolt is in a stable state and has years of successful production use. As such, I feel that leaving it in its current state is the most prudent course of action.
>
> If you are interested in using a more featureful version of Bolt, I suggest that you look at the CoreOS fork called bbolt.

In order to fix the libnetwork issue, I need to change consumers over to the new package, so that I can ultimately pull in this fix: https://github.com/etcd-io/bbolt/pull/122.


This PR uses the import syntax recommended at https://github.com/etcd-io/bbolt#importing-bbolt


@mavenugo PTAL. cc @vieux @johnstep

@carlfischer1 - This will be one change of a few to get that libnetwork issue fixed and pulled into backport.
