### PR TITLE
Use new Zookeeper library

### DIFF
--- a/store/zookeeper/zookeeper.go
+++ b/store/zookeeper/zookeeper.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/docker/libkv"
 	"github.com/docker/libkv/store"
-	zk "github.com/samuel/go-zookeeper/zk"
+	zk "github.com/go-zookeeper/zk"
 )
 
 const (


### PR DESCRIPTION
The old one is dead, and has a dependency that has vanished off the face of the earth.

```
github.com/docker/docker/libnetwork imports
	github.com/docker/libkv/store/zookeeper imports
	github.com/samuel/go-zookeeper/zk tested by
	github.com/samuel/go-zookeeper/zk.test imports
	camlistore.org/pkg/throttle: module camlistore.org@latest found (v0.0.0-20171230002226-a5a65f0d8b22), but does not contain package camlistore.org/pkg/throttle
```
The code builds without further changes.